### PR TITLE
Fix for Hopper conflict with Assembler

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1078,16 +1078,6 @@ const registerGTCEURecipes = (event) => {
 
 	//#endregion
 
-	//#region Hopper
-
-	event.recipes.gtceu.assembler('gtceu:assembler/hopper_wrought_iron')
-		.itemInputs('#forge:chests', '5x #forge:plates/wrought_iron')
-		.itemOutputs('minecraft:hopper')
-		.circuit(8)
-		.duration(200)
-		.EUt(2)
-
-	//#endregion
 
 	//#region Credits
 

--- a/kubejs/server_scripts/minecraft/recipes.js
+++ b/kubejs/server_scripts/minecraft/recipes.js
@@ -597,6 +597,7 @@ const registerMinecraftRecipes = (event) => {
 	event.recipes.gtceu.assembler('hopper_wrought_iron')
 		.itemInputs('#forge:chests', '5x #forge:plates/wrought_iron')
 		.itemOutputs('minecraft:hopper')
+		.circuit(8)
 		.duration(700)
 		.EUt(2)
 


### PR DESCRIPTION
The hopper recipe for the Assembler had a duplicate in kubejs gregtech. Removing it and adding circuit 8 to the original recipe.