### PR TITLE
Change lv chem reactor quest to require any container with rubber fluid

### DIFF
--- a/config/ftbquests/quests/chapters/lv__low_voltage.snbt
+++ b/config/ftbquests/quests/chapters/lv__low_voltage.snbt
@@ -650,7 +650,13 @@
 				}
 				{
 					id: "7DA8B08CC879617F"
-					item: "gtceu:rubber_bucket"
+					item: {
+						Count: 1
+						id: "ftbfiltersystem:smart_filter"
+						tag: {
+							"ftbfiltersystem:filter": "or(nbt(fuzzy:{fluid:{FluidName:\"gtceu:rubber\"}})nbt(fuzzy:{Fluid:{FluidName:\"gtceu:rubber\"}})item(gtceu:rubber_bucket))"
+						}
+					}
 					type: "item"
 				}
 			]


### PR DESCRIPTION

## What is the new behavior?

Small fix - changing the LV chemical reactor quest to require any container with rubber fluid instead of a rubber bucket specifically, in order to be consistent with other fluid requirements in quests.

## Potential Compatibility Issues
N/A

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
gustovafing
