### PR TITLE
Fixes bug where milling #tfg:hardwood would result in softwood pulp instead of the expected hardwood pulp.

### DIFF
--- a/kubejs/server_scripts/tfg/recipes.paper.js
+++ b/kubejs/server_scripts/tfg/recipes.paper.js
@@ -46,10 +46,6 @@ function registerTFGPapermakingRecipes(event) {
 		.duration(160)
 		.EUt(7)
 
-	//Replace macerate logs into macerate softwood logs
-	// event.replaceInput({ id: 'gtceu:macerator/macerate_logs' }, '#minecraft:logs', '#tfg:softwood')
-
-	// event.remove({ id: 'gtceu:macerator/macerate_logs'})
 	removeMaceratorRecipe(event, 'macerate_logs')
 
 	// Create macerator recipes for softwood


### PR DESCRIPTION
## What is the new behavior?
This fixes a bug where milling a #tfg:hardwood item would have the resulting product be Softwood Pulp instead of Hardwood Pulp. 

## Implementation Details
I removed the 'gtceu:macerator/macerate_logs' recipe and added a macerator recipe for #tfg:softwood that is the same as the existing 'macerator_hardwood' recipe

## Outcome
Macerating a #tfg:hardwood item results in Hardwood Pulp as expected

## Additional Information

Softwood pulp milling recipe still shows minecraft:logs as input item but I'm not familiar enough with kubejs to know how to fix it. 
<img width="1288" height="719" alt="image" src="https://github.com/user-attachments/assets/db9a24c1-09c0-4b98-ba62-db564ee93662" />
<img width="795" height="262" alt="image" src="https://github.com/user-attachments/assets/3bf355c1-6efd-484c-9047-695ccf2e6a2d" />


Hardwood Pulp is the correct resulting item though

<img width="625" height="907" alt="image" src="https://github.com/user-attachments/assets/5856ccf1-bcb8-42ac-97fc-7fcd8b7f243c" />



**Discord Username: forsuin**