### PR TITLE
Increasing Jar Capacity For Create Factory Logistics

### DIFF
--- a/defaultconfigs/create_factory_logistics-server.toml
+++ b/defaultconfigs/create_factory_logistics-server.toml
@@ -2,7 +2,7 @@
 factoryGaugeCascadeRequest = true
 #Capacity of the jar in millibuckets
 #Range: 1 ~ 999999999
-jarCapacity = 1000
+jarCapacity = 8000
 #Whether jar packager (bottler) should pick output tanks over combined. Useful if you want to keep basin inputs intact
 jarPackagerPrefersOutputs = true
 


### PR DESCRIPTION
## What is the new behavior?
Increasing the jar capacity to 8000mb for the create fluid automation to help work around the repackager fluid limit of 4 jars per package. This is mainly to help with some recipes that require more then 4b of liquid, or to enable more liquid recipes to be bulk crafted using create. 8000mb was decided as a number divisible by most gregtech machine fluid buffers.

## Outcome
Changed: Jar Capacity 1000mb > 8000mb

ghoulcel
