### PR TITLE
add small pipe mold to vintage press

### DIFF
--- a/kubejs/server_scripts/vintage_improvements/tags.js
+++ b/kubejs/server_scripts/vintage_improvements/tags.js
@@ -44,6 +44,7 @@ function registerVintageImprovementsItemTags(event) {
 	event.add('vintageimprovements:curving_heads', 'gtceu:bottle_extruder_mold')
 	event.add('vintageimprovements:curving_heads', 'gtceu:foil_extruder_mold')
 	event.add('vintageimprovements:curving_heads', 'gtceu:cylinder_casting_mold')
+	event.add('vintageimprovements:curving_heads', 'gtceu:small_pipe_extruder_mold')
 }
 
 


### PR DESCRIPTION
## What is the new behavior?
Added the `Extruder Mold (Small Pipe)` to the curving press to make the Sacks 'n' Such buckle

## Additional Information
The recipe for the buckle was present but the extruder mold was not accepted by the curving press making it impossiable to actually build the buckle using the press

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
JSN1232
