### PR TITLE
remove 2 tags from moss carpets

### DIFF
--- a/kubejs/server_scripts/minecraft/tags.js
+++ b/kubejs/server_scripts/minecraft/tags.js
@@ -74,7 +74,8 @@ const registerMinecraftItemTags = (event) => {
     event.add('tfc:compost_greens_high', 'minecraft:pearlescent_froglight')
     event.add('tfc:compost_greens_high', 'minecraft:verdant_froglight')
     event.add('tfc:compost_greens_high', 'minecraft:ochre_froglight')
-    event.add('tfc:moss', 'minecraft:moss_carpet')
+    //event.add('tfc:moss', 'minecraft:moss_carpet')
+    event.remove('createaddition:plants', 'minecraft:moss_carpet')
 
     event.add('tfc:colored_terracotta', 'minecraft:white_terracotta')
 


### PR DESCRIPTION
## What is the new behavior?
removed 2 tags from moss carpets

## Outcome
#1842 - moss carpets cost 2 moss blocks for 6 carpets.

2 moss blocks = 200mb biomass
6 carpets = 600mb biomass

## Additional Information
any recipe this was removed from by removing the tags has multiple alternatives, including just using the moss blocks. Also, they are carpets