### PR TITLE
Fixed the Food Processor Basil Leaves and Shredded Cheese recipes 

### DIFF
--- a/kubejs/server_scripts/tfg/recipes.food.js
+++ b/kubejs/server_scripts/tfg/recipes.food.js
@@ -658,14 +658,15 @@ function registerTFGFoodRecipes(event) {
 		itemInputs: ['#firmalife:foods/cheeses'],
 		itemOutputs: ['4x firmalife:food/shredded_cheese'],
 		circuit: 30,
-		itemOutputProvider: TFC.isp.of('firmalife:food/shredded_cheese').copyFood()
+		itemOutputProvider: TFC.isp.of('4x firmalife:food/shredded_cheese').copyFood()
 	})
 
 	processorRecipe("basil", 20, 16, {
 		itemInputs: ['firmalife:plant/basil'],
 		itemOutputs: ['2x firmalife:spice/basil_leaves'],
-		circuit: 30
-	})
+		circuit: 30,
+		itemOutputProvider: TFC.isp.of('2x firmalife:spice/basil_leaves').resetFood()
+	})	
 
 	// Ice cream
 	processorRecipe("vanilla_ice_cream", 300, 16, {


### PR DESCRIPTION
## What is the new behavior?
the food processor now doesn't scam people trying to make basil leaves and shredded cheese

## Implementation Details
Shredded Cheese was just a missing 4x, Basil Leaves Recipe was a missing itemOutputProvider field, but now they have a stacking issue in the food processor but it's an issue related to the food processor itself. 

## Outcome
the food processor now doesn't scam people trying to make basil leaves and shredded cheese
fixes #1925 & #1934 