### PR TITLE
all pressure plates to circ 3

### DIFF
--- a/kubejs/server_scripts/ad_astra/recipes.js
+++ b/kubejs/server_scripts/ad_astra/recipes.js
@@ -784,7 +784,7 @@ const registerAdAstraRecipes = (event) => {
 		event.recipes.gtceu.assembler(`tfg:ad_astra_${x.type}_pressure_plate`)
 			.itemInputs('#forge:small_springs', `2x ad_astra:${x.type}_plating_slab`)
 			.itemOutputs(`ad_astra:${x.type}_plating_pressure_plate`)
-			.circuit(0)
+			.circuit(3)
 			.duration(50)
 			.EUt(2)
 

--- a/kubejs/server_scripts/afc/recipes.js
+++ b/kubejs/server_scripts/afc/recipes.js
@@ -63,7 +63,7 @@ const registerAFCRecipes = (event) => {
 
 		event.recipes.gtceu.assembler(`${wood}_pressure_plate`)
 			.itemInputs('#forge:small_springs', `2x afc:wood/planks/${wood}_slab`)
-			.circuit(0)
+			.circuit(3)
 			.itemOutputs(`2x afc:wood/planks/${wood}_pressure_plate`)
 			.duration(50)
 			.EUt(2)

--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1381,7 +1381,7 @@ const registerGTCEURecipes = (event) => {
 	event.recipes.gtceu.assembler('gtceu:treated_pressure_plate')
 		.itemInputs('#forge:small_springs', '2x gtceu:treated_wood_slab')
 		.itemOutputs('gtceu:treated_wood_pressure_plate')
-		.circuit(0)
+		.circuit(3)
 		.duration(50)
 		.EUt(2)
 

--- a/kubejs/server_scripts/gregtech/utility.js
+++ b/kubejs/server_scripts/gregtech/utility.js
@@ -452,7 +452,7 @@ function woodBuilder(event, name, lumber, logs, log, stripped_log, plank, stair,
 			.itemInputs(`2x ${slab}`, '#forge:springs')
 			.itemOutputs(`2x ${pressure_plate}`)
 			.duration(50)
-			.circuit(0)
+			.circuit(3)
 			.EUt(GTValues.VA[GTValues.ULV])
 	}
 

--- a/kubejs/server_scripts/minecraft/recipes.js
+++ b/kubejs/server_scripts/minecraft/recipes.js
@@ -1107,7 +1107,7 @@ const registerMinecraftRecipes = (event) => {
 		event.recipes.gtceu.assembler(`minecraft:${x.type}_pressure_plate`)
 			.itemInputs('#forge:small_springs', `2x ${x.material}`)
 			.itemOutputs(`minecraft:${x.type}_pressure_plate`)
-			.circuit(0)
+			.circuit(3)
 			.duration(50)
 			.EUt(2)
 	})

--- a/kubejs/server_scripts/tfc/recipes.stone.js
+++ b/kubejs/server_scripts/tfc/recipes.stone.js
@@ -49,7 +49,7 @@ function registerTFCStoneRecipes(event) {
 
 		event.recipes.gtceu.assembler(`${stone}_raw_pressure_plate`)
 			.itemInputs('#forge:small_springs', `2x tfc:rock/raw/${stone}_slab`)
-			.circuit(0)
+			.circuit(3)
 			.itemOutputs(`2x tfc:rock/pressure_plate/${stone}`)
 			.duration(50)
 			.EUt(2)

--- a/kubejs/server_scripts/tfc/recipes.wood.js
+++ b/kubejs/server_scripts/tfc/recipes.wood.js
@@ -41,7 +41,7 @@ function registerTFCWoodRecipes(event) {
 
 		event.recipes.gtceu.assembler(`${wood}_pressure_plate`)
 			.itemInputs('#forge:small_springs', `2x tfc:wood/planks/${wood}_slab`)
-			.circuit(0)
+			.circuit(3)
 			.itemOutputs(`2x tfc:wood/planks/${wood}_pressure_plate`)
 			.duration(50)
 			.EUt(2)


### PR DESCRIPTION
## What is the new behavior?
changed all pressure plate assembler recipes to use circuit 3 to avoid most conflicts, issue stemmed from pressure plates needing no circuit and also accepting any spring. Some recipes such as creates precision mechanism requires a gold plate and a gold spring, this was conflicting with "light weighted pressure plate"