### PR TITLE
Add "Recipes.Final" script

### DIFF
--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -1676,16 +1676,6 @@ const registerCreateRecipes = (event) => {
 			.EUt(7)
 	})
 
-	//Allow automatic scraping by using sequenced assembly
-	event.forEachRecipe({ type: 'tfc:scraping' }, r => {
-		let originalRecipeIngredient = r.json.get("ingredient").get("item");
-		let output = r.originalRecipeResult;
-
-		event.recipes.createSequencedAssembly([output], originalRecipeIngredient, [
-			event.recipes.createDeploying(originalRecipeIngredient, [originalRecipeIngredient, '#tfc:knives']).keepHeldItem()
-		]).transitionalItem(originalRecipeIngredient).loops(16)
-	})
-
 	// #endregion
 	
 	//#region Create 6 Logistics

--- a/kubejs/server_scripts/main_server_script.js
+++ b/kubejs/server_scripts/main_server_script.js
@@ -271,6 +271,7 @@ ServerEvents.recipes(event => {
 	registerVintageImprovementsRecipes(event)
 	registerWaterFlasksRecipes(event)
 	registerWABRecipes(event)
+	registerFinalRecipes(event)
 })
 
 TaCZServerEvents.gunIndexLoad((event) => {

--- a/kubejs/server_scripts/recipes.final.js
+++ b/kubejs/server_scripts/recipes.final.js
@@ -1,0 +1,14 @@
+/**
+ * @param {Internal.RecipesEventJS} event 
+ */
+function registerFinalRecipes(event) {
+    //Allow automatic scraping by using sequenced assembly
+	event.forEachRecipe({ type: 'tfc:scraping' }, r => {
+		let originalRecipeIngredient = r.json.get("ingredient").get("item");
+		let output = r.originalRecipeResult;
+
+		event.recipes.createSequencedAssembly([output], originalRecipeIngredient, [
+			event.recipes.createDeploying(originalRecipeIngredient, [originalRecipeIngredient, '#tfc:knives']).keepHeldItem()
+		]).transitionalItem(originalRecipeIngredient).loops(16)
+	})
+}


### PR DESCRIPTION
-# no way, i'm making a contribution :o
## What is the new behavior?

While i was playing, i noticed that new Scraping recipes where added (Flax), however, i could also notice that some of the new scraping recipes didnt have automatic implementations on Create using Sequenced Assembly.

From what i could tell, the original recipe utilized all the registered scraping recipes, to create equivalents using create sequenced assembly + a tfc knife. However, this recipe was running prior to TFG registering its own recipes, causing the contradiction.

As a result, i created a new file called "recipes.final", ideally any recipe that acts upon existing recipe types to create equivalents should be here, as this will be called at the end of the Recipe registration procedure

## Implementation Details

Added a new file which it's method gets called at the end of the registration method

## Outcome

All recipes that use scrapping can now be worked on a Sequenced Assembly setup.

## Additional Information

<img width="970" height="361" alt="image" src="https://github.com/user-attachments/assets/027bae47-4c02-4e18-8bff-6ac1a12a4a27" />