### PR TITLE
Unify emitter recipes

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -1576,12 +1576,42 @@ const registerGTCEURecipes = (event) => {
 		D: 'gtceu:palladium_substation'
 	}).addMaterialInfo().id('gtceu:shaped/power_substation')
 
-	event.replaceInput({ id: 'gtceu:shaped/field_generator_hv' }, 'gtceu:quantum_eye', 'tfg:cryo_fluix_pearl')
 	event.replaceInput({ id: 'gtceu:assembler/field_generator_hv' }, 'gtceu:quantum_eye', 'tfg:cryo_fluix_pearl')
-	event.replaceInput({ id: 'gtceu:shaped/field_generator_ev' }, 'minecraft:nether_star', 'gtceu:quantum_eye')
 	event.replaceInput({ id: 'gtceu:assembler/field_generator_ev' }, 'minecraft:nether_star', 'gtceu:quantum_eye')
-	event.replaceInput({ id: 'gtceu:shaped/field_generator_iv' }, 'gtceu:quantum_star', 'minecraft:nether_star')
 	event.replaceInput({ id: 'gtceu:assembler/field_generator_iv' }, 'gtceu:quantum_star', 'minecraft:nether_star')
+
+	event.recipes.gtceu.shaped('gtceu:hv_field_generator', [
+		'ABA',
+		'CDC',
+		'ABA'
+	], {
+		A: ChemicalHelper.get(TagPrefix.wireGtQuadruple, GTMaterials.MercuryBariumCalciumCuprate , 1),
+		B: ChemicalHelper.get(TagPrefix.plate, GTMaterials.StainlessSteel, 1),
+		C: '#gtceu:circuits/hv',
+		D: 'tfg:cryo_fluix_pearl'
+	}).addMaterialInfo().id('gtceu:shaped/field_generator_hv')
+
+	event.recipes.gtceu.shaped('gtceu:ev_field_generator', [
+		'ABA',
+		'CDC',
+		'ABA'
+	], {
+		A: ChemicalHelper.get(TagPrefix.wireGtQuadruple, GTMaterials.UraniumTriplatinum , 1),
+		B: ChemicalHelper.get(TagPrefix.plateDouble, GTMaterials.Titanium, 1),
+		C: '#gtceu:circuits/ev',
+		D: 'gtceu:quantum_eye'
+	}).addMaterialInfo().id('gtceu:shaped/field_generator_ev')
+
+	event.recipes.gtceu.shaped('gtceu:iv_field_generator', [
+		'ABA',
+		'CDC',
+		'ABA'
+	], {
+		A: ChemicalHelper.get(TagPrefix.wireGtQuadruple, GTMaterials.SamariumIronArsenicOxide , 1),
+		B: ChemicalHelper.get(TagPrefix.plateDouble, GTMaterials.TungstenSteel, 1),
+		C: '#gtceu:circuits/iv',
+		D: 'minecraft:nether_star'
+	}).addMaterialInfo().id('gtceu:shaped/field_generator_iv')
 
 	event.remove({ id: 'gtceu:chemical_bath/quantum_eye' })
 	event.recipes.gtceu.chemical_bath('tfg:quantum_eye')


### PR DESCRIPTION
## What is the new behavior?
The field generator recipes were inconsistent between the crafting table and assembler

## Implementation Details
Added replaceInputs for the assembler recipes to match the crafting table recipes of field generators

Discord: Spicy Noodles