### PR TITLE
Adjust claims

### DIFF
--- a/defaultconfigs/ftbranks/ranks.snbt
+++ b/defaultconfigs/ftbranks/ranks.snbt
@@ -5,7 +5,7 @@
 		condition: "always_active"
 		ftbranks.name_format: "&a{name}"
 		ftbchunks.max_claimed: 50
-		ftbchunks.max_force_loaded: 3
+		ftbchunks.max_force_loaded: 8
 		ftbchunks.chunk_load_offline: false
 		command.trashcan: true
 		command.enderchest: false
@@ -15,7 +15,7 @@
 		power: 50
 		ftbranks.name_format: "&e{name}"
 		ftbchunks.max_claimed: 200
-		ftbchunks.max_force_loaded: 5
+		ftbchunks.max_force_loaded: 10
 		ftbchunks.chunk_load_offline: true
 	}
 	moderator_girl: {
@@ -23,14 +23,14 @@
 		power: 51
 		ftbranks.name_format: "&d{name}"
 		ftbchunks.max_claimed: 200
-		ftbchunks.max_force_loaded: 5
+		ftbchunks.max_force_loaded: 10
 	}
 	moderator: {
 		name: "Moderator"
 		power: 51
 		ftbranks.name_format: "&b{name}"
 		ftbchunks.max_claimed: 200
-		ftbchunks.max_force_loaded: 5
+		ftbchunks.max_force_loaded: 10
 	}
 	admin: {
 		name: "Admin"


### PR DESCRIPTION
Adjusting some of the claim limits because more of our space progression requires having machines set up in different dimensions in different places, and a limit of 3 isn't going to work with that. Are these numbers good do you think?

Unrelated but someone said they couldn't claim chunks in the nether/beneath, do you know why that would be? I don't see it in any files