### PR TITLE
add  rock/smooth tag to smooth stone

### DIFF
--- a/kubejs/server_scripts/minecraft/tags.js
+++ b/kubejs/server_scripts/minecraft/tags.js
@@ -100,6 +100,8 @@ const registerMinecraftItemTags = (event) => {
 	event.add('forge:smooth_stone_slab', 'minecraft:polished_deepslate_slab')
 	event.add('forge:smooth_stone_slab', 'minecraft:polished_blackstone_slab')
     event.add('forge:smooth_stone_slab', 'minecraft:polished_blackstone_brick_slab')
+
+    event.add('tfc:rock/smooth', 'minecraft:smooth_stone')
 }
 
 const registerMinecraftBlockTags = (event) => {


### PR DESCRIPTION
## What is the new behavior?

* Adds the specified tag to smooth stone so that it can be used to craft comparators n others

## Implementation Details

It just adds a tag

## Outcome

I can use smooth stone for comparators :D

## Additional Information

None

## Potential Compatibility Issues
None

Yknow who it is