### PR TITLE
Add shapeless p2p recipes

### DIFF
--- a/kubejs/server_scripts/ae2/recipes.js
+++ b/kubejs/server_scripts/ae2/recipes.js
@@ -327,6 +327,17 @@ const registerAE2Recipes = (event) => {
 		D: '#forge:gems/fluix',
 	}).addMaterialInfo().id('tfg:crafting/me_p2p_tunnel')
 
+	event.shapeless('ae2:me_p2p_tunnel', ['ae2:me_p2p_tunnel'])
+		.id('tfg:shapeless/me_p2p_tunnel')
+	event.shapeless('ae2:redstone_p2p_tunnel', ['ae2:redstone_p2p_tunnel'])
+		.id('tfg:shapeless/redstone_p2p_tunnel')
+	event.shapeless('ae2:item_p2p_tunnel', ['ae2:item_p2p_tunnel'])
+		.id('tfg:shapeless/item_p2p_tunnel')
+	event.shapeless('ae2:fluid_p2p_tunnel', ['ae2:fluid_p2p_tunnel'])
+		.id('tfg:shapeless/fluid_p2p_tunnel')
+	event.shapeless('ae2:light_p2p_tunnel', ['ae2:light_p2p_tunnel'])
+		.id('tfg:shapeless/light_p2p_tunnel')
+
 	// ME Chest
 	event.recipes.gtceu.shaped('ae2:chest', [
 		'AEA',


### PR DESCRIPTION
## What is the new behavior?
Adds shapeless recipes for p2p -> p2p. This is to quickly clear names from p2p tunnels similar to how you can clear filters in the crafting grid.

## Outcome
With the advanced memory card, you can't remove names from p2p tunnels completely so this acts as a convenience.

Discord: Spicy Noodles (lol)