### PR TITLE
expand the Facade Whitelist 

### DIFF
--- a/kubejs/server_scripts/tfg/tags.facades.js
+++ b/kubejs/server_scripts/tfg/tags.facades.js
@@ -42,6 +42,9 @@ function registerFacadeWhitelistTags(event) {
 		//reconstituted stone blocks
 		'minecraft:smooth_stone',
 		'minecraft:stone_bricks',
+		'minecraft:cracked_stone_bricks',
+		'minecraft:chiseled_stone_bricks',
+		'minecraft:mossy_stone_bricks',
 		
 		//rnr shingles
 		'rnr:ceramic_roof',


### PR DESCRIPTION
## What is the new behavior?

Facade Whitelist is expanded to include some missing blocks.

1. add Reconstituted Stone blocks (likely missing due to oversight)
2. fixes Domum Ornamentum Bricks missing (due to a typo)

## Implementation Details

Both groups seem intended to be whitelisted. Of the blocks, only the "normal" Reconstituted Stone is already whitelisted (due to being a **storage block**).

This PR adds each missing Reconstituted Stone variant individually, but using `forge` or `minecraft` tags for stone/bricks (rather than the `tfc` tags) may be better. I'm unfamiliar with the best & recommended practices.