### PR TITLE
Tallow and fish oil changes for 0.11.9

### DIFF
--- a/kubejs/assets/gtceu/lang/en_us.json
+++ b/kubejs/assets/gtceu/lang/en_us.json
@@ -132,7 +132,7 @@
   "material.gtceu.damascus_steel": "Swine-steel",
   "material.gtceu.air": "Earth Air",
   "material.gtceu.liquid_air": "Liquid Earth Air",
-  "material.gtceu.fish_oil": "Tallowate",
+  "material.gtceu.fish_oil": "Fish Oil",
   "material.gtceu.cooperite": "Cooperite",
   "material.gtceu.armalcolite": "Armalcolite",
   "material.gtceu.desh": "Desh",

--- a/kubejs/server_scripts/firmalife/tags.js
+++ b/kubejs/server_scripts/firmalife/tags.js
@@ -82,6 +82,7 @@ const registerFirmaLifeFluidTags = (event) => {
     event.add('firmalife:mixable', 'afc:maple_syrup')
     event.add('firmalife:mixable', 'afc:birch_syrup')
 
+    event.add('firmalife:oils', 'tfc:tallow')
     event.add('firmalife:oils', 'gtceu:seed_oil')
     event.add('firmalife:oils', 'gtceu:fish_oil')
     event.add('firmalife:oils', 'tfg:triglyceride_oil')

--- a/kubejs/server_scripts/tfg/powergen/recipes.biodiesel.js
+++ b/kubejs/server_scripts/tfg/powergen/recipes.biodiesel.js
@@ -56,9 +56,25 @@ function registerTFGBiodieselRecipes(event) {
 		.duration(20 * 10)
 		.EUt(GTValues.VHA[GTValues.ULV])
 
+	event.recipes.gtceu.chemical_reactor(`tallow_alcohol_biodiesel`)
+		.inputFluids("#tfc:alcohols 1000", Fluid.of('tfc:tallow', 6000))
+		.itemInputs('#forge:tiny_dusts/sodium_hydroxide')
+		.outputFluids(Fluid.of('gtceu:bio_diesel', 6000))
+		.duration(20 * 10)
+		.EUt(GTValues.VHA[GTValues.ULV])
+
+
 	// So you can craft Biodiesel without Chemical Reactor
 	event.recipes.gtceu.mixer(`tfg:fish_oil_alcohol_biodiesel`)
 		.inputFluids("#tfc:alcohols 1000", Fluid.of('gtceu:fish_oil', 1000))
+		.itemInputs('#forge:tiny_dusts/sodium_hydroxide')
+		.outputFluids(Fluid.of('gtceu:bio_diesel', 500))
+		.duration(20 * 10)
+		.EUt(GTValues.VHA[GTValues.ULV])
+
+
+	event.recipes.gtceu.mixer(`tfg:tallow_alcohol_biodiesel`)
+		.inputFluids("#tfc:alcohols 1000", Fluid.of('tfc:tallow', 1000))
 		.itemInputs('#forge:tiny_dusts/sodium_hydroxide')
 		.outputFluids(Fluid.of('gtceu:bio_diesel', 500))
 		.duration(20 * 10)

--- a/kubejs/server_scripts/tfg/powergen/recipes.biodiesel.js
+++ b/kubejs/server_scripts/tfg/powergen/recipes.biodiesel.js
@@ -107,4 +107,18 @@ function registerTFGBiodieselRecipes(event) {
 		.outputFluids(Fluid.of('gtceu:glycerol'), Fluid.of('gtceu:bio_diesel', 6000))
 		.duration(20 * 10)
 		.EUt(GTValues.VHA[GTValues.LV])
+
+	event.recipes.gtceu.chemical_reactor(`tallow_methanol_biodiesel`)
+		.inputFluids(Fluid.of('tfc:tallow', 6000), Fluid.of('gtceu:methanol', 1000))
+		.itemInputs('#forge:tiny_dusts/sodium_hydroxide')
+		.outputFluids(Fluid.of('gtceu:glycerol'), Fluid.of('gtceu:bio_diesel', 6000))
+		.duration(20 * 10)
+		.EUt(GTValues.VHA[GTValues.LV])
+
+	event.recipes.gtceu.chemical_reactor(`tallow_ethanol_biodiesel`)
+		.inputFluids(Fluid.of('tfc:tallow', 6000), Fluid.of('gtceu:ethanol', 1000))
+		.itemInputs('#forge:tiny_dusts/sodium_hydroxide')
+		.outputFluids(Fluid.of('gtceu:glycerol'), Fluid.of('gtceu:bio_diesel', 6000))
+		.duration(20 * 10)
+		.EUt(GTValues.VHA[GTValues.LV])
 }

--- a/kubejs/server_scripts/tfg/powergen/recipes.boiler.js
+++ b/kubejs/server_scripts/tfg/powergen/recipes.boiler.js
@@ -62,24 +62,22 @@ function registerTFGBoilerRecipes(event) {
 		.duration(200)
 		.dimension('minecraft:overworld')
 
-	// fish oil (aka tallowate) extraction
+	event.recipes.gtceu.steam_boiler('tfg:tallow')
+		.inputFluids(Fluid.of('tfc:tallow', 160))
+		.duration(200)
+		.dimension('minecraft:overworld')
+
+	// fish oil extraction
 	event.recipes.gtceu.extractor(`tfg:fish_oil`)
 		.itemInputs('#minecraft:fishes')
-		.outputFluids(Fluid.of('gtceu:fish_oil', 200))
+		.outputFluids(Fluid.of('gtceu:fish_oil', 400))
 		.duration(40)
 		.EUt(4)
 
 	event.recipes.gtceu.extractor(`tfg:tallow`)
 		.itemInputs('tfc:blubber')
-		.outputFluids(Fluid.of('tfc:tallow', 200))
+		.outputFluids(Fluid.of('tfc:tallow', 400))
 		.duration(40)
-		.EUt(4)
-
-	// you get tallow from killing things like orcas, so this seems close enough
-	event.recipes.gtceu.mixer('tallow_to_fish_oil')
-		.inputFluids('tfc:tallow 100', 'tfc:lye 100')
-		.outputFluids('gtceu:fish_oil 200')
-		.duration(100)
 		.EUt(4)
 
 	// Seed oil


### PR DESCRIPTION
rather than replacing fish oil with tallowate altogether, we can just use tallow to make biodiesel directly, which is more realistic and lets us preserve fish oil

also making tallow part of firmalife:oils and making it a boiler fuel as well so it's in-line with other oils

removed the tallow -> fish oil recipe because they're functionally identical now

i also buffed the output of getting tallow and fish oil from extractors from 200mb to 400mb to compensate for this. subject to balancing ofc

p.s. since blubber is being replaced by animal fat, currently the only way to get fish oil now is by extracting fish. maybe we want to add a new way of getting fish oil in the future. (probably make blubber and animal fat separate items eventually, but it doesn't really matter right now since again, fish oil and tallow are pretty much identical now)

app.le on discord
