### PR TITLE
Remove "Visit moon" from Liquid Fluix quest in AE2 chapter

### DIFF
--- a/config/ftbquests/quests/chapters/applied_energistics_2.snbt
+++ b/config/ftbquests/quests/chapters/applied_energistics_2.snbt
@@ -218,13 +218,6 @@
 					id: "432E105A84AEA630"
 					type: "checkmark"
 				}
-				{
-					dimension: "ad_astra:moon"
-					disable_toast: true
-					icon: "tfg:marker/moon"
-					id: "6A4F5147475443C5"
-					type: "dimension"
-				}
 			]
 			title: "{quests.ae2.fluix_liquid.title}"
 			x: -3.5d


### PR DESCRIPTION
You're already guaranteed to have been on the moon at that point, and the task blocks progression since you usually first get fluix on Earth.
<img width="623" height="243" alt="image" src="https://github.com/user-attachments/assets/fa7e6a73-d0d5-43eb-a627-e0982cdaa7c1" />
