### PR TITLE
Remove hydration from freezedried food

### DIFF
--- a/kubejs/server_scripts/tfg/food/recipes.food.js
+++ b/kubejs/server_scripts/tfg/food/recipes.food.js
@@ -464,7 +464,7 @@ function registerTFGFoodRecipes(event) {
 			circuit: 7,
 			itemInputs: [fruit.id, 'tfg:foil_pack', 'tfg:dry_ice'],
 			itemOutputs: [`tfg:food/freeze_dried/${fruit.name}`],
-			itemOutputProvider: TFC.isp.of(`tfg:food/freeze_dried/${fruit.name}`).copyOldestFood().removeTrait('firmalife:dried').addTrait('tfg:freeze_dried').meal((food) => food, [(portion) => portion.waterModifier(0)])
+			itemOutputProvider: TFC.isp.of(`tfg:food/freeze_dried/${fruit.name}`).copyOldestFood().removeTrait('firmalife:dried').addTrait('tfg:freeze_dried')
 		})
 	})
 


### PR DESCRIPTION
Change all freezedried food to give no hydration. This affects all mealbags ~~and freezedried fruit bags~~ that contain ingredients that would otherwise give you hydration. Freezedrying removes all moisture from food, so it should not provide any water.

