### PR TITLE
Fix quest MV quad pipe accepted items

### DIFF
--- a/config/ftbquests/quests/chapters/mv__medium_voltage.snbt
+++ b/config/ftbquests/quests/chapters/mv__medium_voltage.snbt
@@ -1221,7 +1221,7 @@
 					Count: 1
 					id: "ftbfiltersystem:smart_filter"
 					tag: {
-						"ftbfiltersystem:filter": "or(item(gtceu:aluminium_quadruple_fluid_pipe)item(gtceu:blue_steel_quadruple_fluid_pipe)item(gtceu:steel_quadruple_fluid_pipe))"
+						"ftbfiltersystem:filter": "or(item_tag(forge:quadruple_fluid_pipes)item_tag(forge:nonuple_fluid_pipes))"
 					}
 				}
 				title: "Multiple Channel Potin Pipes, please"


### PR DESCRIPTION
Accept any quadruple or nonuple pipe based on item tags, instead of one of three specific items. This puts it in line with the actual quest text.
<img width="613" height="606" alt="image" src="https://github.com/user-attachments/assets/1275f31b-3413-4ed5-8d10-4ed6d5692da6" />
<img width="794" height="557" alt="image" src="https://github.com/user-attachments/assets/4de4fd12-42e4-4ad2-a9d7-22709e9b534c" />
