### PR TITLE
Add circuit to Silicon Tetrachloride

### DIFF
--- a/kubejs/server_scripts/tfg/ores_and_materials/recipes.zirconium.js
+++ b/kubejs/server_scripts/tfg/ores_and_materials/recipes.zirconium.js
@@ -9,6 +9,7 @@ function registerTFGZirconiumRecipes(event) {
 		.inputFluids('gtceu:chlorine 4000')
 		.outputFluids('tfg:silicon_tetrachloride 1000')
 		.duration(20 * 20)
+		.circuit(1)
 		.EUt(GTValues.VA[GTValues.MV])
 
 	event.recipes.gtceu.chemical_reactor('tfg:silicon_tetrachloride_decomp')


### PR DESCRIPTION
Fixes #2383, deconflicts with Polydimethylsiloxane (and various other recipes!)

Pretty sure this doesn't introduce any new conflicts, since there's no chemreactor recipes that have circuit one and only silicon, only chlorine, or both.