### PR TITLE
Add circuit to carbon monoxide from dioxide recipe

### DIFF
--- a/kubejs/startup_scripts/gtceu/constants.js
+++ b/kubejs/startup_scripts/gtceu/constants.js
@@ -387,6 +387,9 @@ global.ADD_CIRCUIT = /** @type {const} */ ([
 
     { recipeId: "gtceu:chemical_reactor/sodium_bicarbonate_from_salt", circuitNumber: 2 },
     { recipeId: "gtceu:large_chemical_reactor/sodium_bicarbonate_from_salt", circuitNumber: 2 },
+
+    { recipeId: "gtceu:chemical_reactor/carbon_monoxide_from_dioxide", circuitNumber: 1 },
+    { recipeId: "gtceu:large_chemical_reactor/carbon_monoxide_from_dioxide", circuitNumber: 1 },
     
     { recipeId: "gtceu:chemical_reactor/acetic_acid_from_methanol", circuitNumber: 1 },
     { recipeId: "gtceu:large_chemical_reactor/acetic_acid_from_methanol", circuitNumber: 1 },


### PR DESCRIPTION
## What is the new behavior?
Adds circuit 1 to the carbon monoxide from dioxide recipe. This is to help with a recipe "conflict" in the tungsten line if you use the same chemical reactor for both carbon dioxide and sodium bicarbonate (carbon + carbon dioxide will react first to make useless carbon monoxide rather than using carbon + oxygen to make carbon dioxide)

## Implementation Details
Adds circuit 1, this matches other recipes for carbon monoxide which also have circuit 1
