### PR TITLE
Don't backup DistantHorizons LODs

### DIFF
--- a/config/ftbbackups2.json
+++ b/config/ftbbackups2.json
@@ -65,7 +65,7 @@
 	   *path/ends/with.txt             Any files who's path ends with
 	   *path/contains*                 Any files who's path contains
 	*/
-	"excluded": [],
+	"excluded": ["DistantHorizons.sqlite"],
 	// The dimension used when creating backup preview image, specify "all" to enable automatic detection of primary dimension (can be very slow)
 	"preview_dimension": "minecraft:overworld"
 }


### PR DESCRIPTION
Exclude "DistantHorizons.sqlite" from ftbbackups2 since that's not critical data and leads to a lot of backup bloat.

DistantHorizons is not part of the modpack but we're trying to include sensible defaults anyway for people that want to install it.

Implementation details:
All LODs are saved in a file called DistantHorizons.sqlite, there's several of these files (one per dimension) but they're all called the same.