### PR TITLE
Move boiled eggs to food processor to deconflict with cooked egg, fix pickled egg recipe name typo

### DIFF
--- a/kubejs/server_scripts/tfg/food/recipes.food.js
+++ b/kubejs/server_scripts/tfg/food/recipes.food.js
@@ -575,14 +575,6 @@ function registerTFGFoodRecipes(event) {
 
 	cookingRecipe("baked_potato", "tfc:food/potato", "tfc:food/baked_potato")
 
-	processorRecipe("boiled_egg", 200, 16, {
-		circuit: 1,
-		itemInputs: ["#firmalife:foods/raw_eggs"],
-		fluidInputs: ["#tfg:clean_water 200"],
-		itemOutputs: ["tfc:food/boiled_egg"],
-		itemOutputProvider: TFC.isp.of("tfc:food/boiled_egg").copyFood()
-	})
-
 	cookingRecipe("cooked_rice", "tfc:food/rice_grain", "tfc:food/cooked_rice", "#tfg:clean_water 200")
 
 	processorRecipe("pasta_tomato_sauce", 60, 8, {
@@ -671,6 +663,14 @@ function registerTFGFoodRecipes(event) {
 		itemOutputs: ['tfg:food/calorie_paste'],
 		fluidInputs: [Fluid.of('gtceu:fermented_biomass', 40)],
 		itemOutputProvider: TFC.isp.of('tfg:food/calorie_paste').copyOldestFood().addTrait('tfg:freeze_dried')
+	})
+
+	processorRecipe("boiled_egg", 200, 16, {
+		circuit: 1,
+		itemInputs: ["#firmalife:foods/raw_eggs"],
+		fluidInputs: ["#tfg:clean_water 200"],
+		itemOutputs: ["tfc:food/boiled_egg"],
+		itemOutputProvider: TFC.isp.of("tfc:food/boiled_egg").copyFood()
 	})
 
 	//Kelp
@@ -928,7 +928,7 @@ function registerTFGFoodRecipes(event) {
 		itemOutputProvider: TFC.isp.of('4x firmalife:food/bacon').copyFood()
 	})
 
-	processorRecipe("picked_egg", 1000, 8, {
+	processorRecipe("pickled_egg", 1000, 8, {
 		circuit: 1,
 		itemInputs: ['minecraft:clay_ball', 'tfc:powder/wood_ash', 'tfc:powder/salt', 'tfc:food/boiled_egg'],
 		itemOutputs: ['firmalife:food/pickled_egg'],


### PR DESCRIPTION
Fixes #2357 

**Implementation details:**
Moved boiled egg from food oven to food processor, added circuit 1 to make sure it doesn't create any new conflicts. Dropped EUt a bit (16 instead of 30).

**Other notes:**
Can't have circuits on the food oven so we can't just add a circuit to that one.