### PR TITLE
Remove macaw's stuff from boiler recipes for easier menu nav

### DIFF
--- a/kubejs/server_scripts/macaws_for_tfc/recipes.js
+++ b/kubejs/server_scripts/macaws_for_tfc/recipes.js
@@ -6,7 +6,6 @@
  * @param {Internal.RecipesEventJS} event 
  */
 function registerMacawsForTFCRecipes(event) {
-	event.add(mcw_tfc_aio)
 	event.replaceInput({ mod: 'mcw_tfc_aio' }, 'minecraft:stick', '#forge:rods/wooden')
 	event.replaceInput({ mod: 'mcw_tfc_aio' }, 'minecraft:string', '#forge:string')
 	event.replaceInput({ mod: 'mcw_tfc_aio' }, 'minecraft:glass', '#forge:glass')


### PR DESCRIPTION
removes macaw's stuff from boiler recipes for easier menu nav

https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/2394

shortens the list of recipes for the steam boiler and large boilers DRASTICALLY by removing all Macaw's All-in-one for TFC recipes for them, allowing the menu to be navigated much more easily

Federation President Bravo