### PR TITLE
Fix drills durability (fix sharp tools BlockEvent filter)

### DIFF
--- a/kubejs/server_scripts/tfg/events.interactions.js
+++ b/kubejs/server_scripts/tfg/events.interactions.js
@@ -503,18 +503,19 @@ BlockEvents.rightClicked(event => {
 });
 
 // Makes scythes, hoes, and knives take damage when cutting grass
-BlockEvents.broken('tfc:mineable_with_sharp_tool', event => {
-	let player = event.player;
-	let toolUsed = player.mainHandItem;
+BlockEvents.broken(event => {
+	const { server, item, player, block } = event;
 
-	if (!toolUsed.hasTag('tfc:sharp_tools')) {
+	if (!block.hasTag('tfc:mineable_with_sharp_tool') || !toolUsed.hasTag('tfc:sharp_tools')) {
 		return;
 	}
+	
+	let toolUsed = player.mainHandItem;
 
 	if (!player.isCreative()) {
 		toolUsed.damageValue++;
 		if (toolUsed.damageValue >= toolUsed.maxDamage) {
-			event.server.runCommandSilent(`playsound minecraft:item.shield.break player ${player.username} ${player.x} ${player.y} ${player.z} 1 1 1`);
+			server.runCommandSilent(`playsound minecraft:item.shield.break player ${player.username} ${player.x} ${player.y} ${player.z} 1 1 1`);
 			toolUsed.count--;
 		}
 	}


### PR DESCRIPTION
This fixes https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/2374

**Implementation details:**
`BlockEvents.broken('tfc:mineable_with_sharp_tool', event => {`

This is trying to filter by block tag, but you can't register to events by tag, only by ID. Since nothing matches, kubejs registers this for every block break event. (I tried the tag with # but that also doesn't work)

**Notes**
I'm not sure why kubejs doesn't just silently or loudly fail to register for events when the ID doesn't match (I'm asking on their discord) but the fix will work either way