### PR TITLE
Boiler recipe cleanup

### DIFF
--- a/kubejs/server_scripts/tfg/powergen/recipes.boiler.js
+++ b/kubejs/server_scripts/tfg/powergen/recipes.boiler.js
@@ -24,7 +24,6 @@ function registerTFGBoilerRecipes(event) {
 	event.remove({ id: /gtceu:....._boiler\/.*bundle.*/ })
 	event.remove({ id: /gtceu:....._boiler\/.*lectern.*/ })
 	event.remove({ id: /gtceu:....._boiler\/.*cartography.*/})
-	event.remove({ id: /gtceu:....._boiler\/.*bundle.*/ })
 	event.remove({ id: /gtceu:....._boiler\/.*ladder.*/ })
 	event.remove({ id: /gtceu:....._boiler\/.*crossbow.*/ })
 	event.remove({ id: /gtceu:....._boiler\/.*jukebox.*/ })


### PR DESCRIPTION
Cleans up the boiler recipe tab, removing ones that are unlikely to be used (macaw's, furniture, etc)

Re-adds saplings, logs and planks as fuel in tags instead

Credit to [thederpysockdude123](https://github.com/thederpysockdude123) as this is just expanding a bit on what they are doing in their pull request (https://github.com/TerraFirmaGreg-Team/Modpack-Modern/pull/2415)

app.le on discord