### PR TITLE
Fix toolUsed being referenced before definition

### DIFF
--- a/kubejs/server_scripts/tfg/events.interactions.js
+++ b/kubejs/server_scripts/tfg/events.interactions.js
@@ -506,11 +506,11 @@ BlockEvents.rightClicked(event => {
 BlockEvents.broken(event => {
 	const { server, item, player, block } = event;
 
+	let toolUsed = player.mainHandItem;
+	
 	if (!block.hasTag('tfc:mineable_with_sharp_tool') || !toolUsed.hasTag('tfc:sharp_tools')) {
 		return;
 	}
-	
-	let toolUsed = player.mainHandItem;
 
 	if (!player.isCreative()) {
 		toolUsed.damageValue++;


### PR DESCRIPTION
Got the order mixed up in the final refactoring, currently it's spamming soft errors in the log.