### PR TITLE
add maintenance hatches to the the cleanroom quest

### DIFF
--- a/config/ftbquests/quests/chapters/hv__high_voltage.snbt
+++ b/config/ftbquests/quests/chapters/hv__high_voltage.snbt
@@ -515,7 +515,7 @@
 							"ftbfiltersystem:filter": "or(item(gtceu:auto_maintenance_hatch)item(gtceu:maintenance_hatch))"
 						}
 					}
-					title: "{quests.high_voltage.cleanroom.task}Maintenance Hatch or Auto Maintenance Hatch"
+					title: "{quests.high_voltage.cleanroom.task}"
 					type: "item"
 				}
 			]


### PR DESCRIPTION
adds maintenance hatches to the cleanroom quest, as the configurable maintenance hatch does not work, thus this serves as a good way to indicate to players that only the other two types of maintenance hatches will work.

also makes the numbers of the items needed set to 1 for plascrete and cleanroom glass, as well as making the glass an optional task (these changes were already being made, just added them here as well for convenience.)

Federation President Bravo