### PR TITLE
Remove localization from loading screen

### DIFF
--- a/config/fancymenu/customization/gui_loading_screen.txt
+++ b/config/fancymenu/customization/gui_loading_screen.txt
@@ -91,7 +91,7 @@ element {
 
 element {
   interactable = false
-  source = {"placeholder":"local","values":{"key":"tfg.gui.menu.field_guide_splash_text"}}
+  source = Tip: Read the field guide!!!
   source_mode = direct
   shadow = true
   scale = 1.0
@@ -158,7 +158,7 @@ element {
 
 element {
   interactable = false
-  source = {"placeholder":"local","values":{"key":"tfg.gui.menu.ram_usage"}} {"placeholder":"usedram"}MB/ {"placeholder":"maxram"}MB
+  source = RAM: {"placeholder":"usedram"}MB/ {"placeholder":"maxram"}MB
   source_mode = direct
   shadow = true
   scale = 0.8
@@ -225,7 +225,7 @@ element {
 
 element {
   interactable = false
-  source = {"placeholder":"local","values":{"key":"tfg.gui.menu.fps_count"}} {"placeholder":"fps"}
+  source = FPS: {"placeholder":"fps"}
   source_mode = direct
   shadow = true
   scale = 0.8


### PR DESCRIPTION
Localization files are only loaded after all mods are initialized. The FancyMenu loading screen is loaded _before_ all mods.
<img width="1007" height="751" alt="image" src="https://github.com/user-attachments/assets/9d0ad526-97ee-472a-9bcc-631894fde8aa" />

Currently that leads to the string "tfg.gui.menu.field _guides_ splash_text" being shown for most of the loading screen, and then near the end it briefly actually shows the correct localization, right before it disappears again to do the main menu.

This doesn't seem worth the tradeoff, it looks quite broken. imo let's revert to this being plain English.

<img width="997" height="747" alt="image" src="https://github.com/user-attachments/assets/603252b9-3ec7-48e0-991f-146ef7d407b6" />
