### PR TITLE
Fertilizer values for various gt dusts

### DIFF
--- a/kubejs/server_scripts/tfc/data.js
+++ b/kubejs/server_scripts/tfc/data.js
@@ -76,12 +76,38 @@ const registerTFCFertilizers = (event) => {
 	event.fertilizer('gtceu:small_phosphorus_dust', null, 0.037, null)
 	event.fertilizer('gtceu:phosphorus_dust', null, 0.15, null)
 
+	event.fertilizer('gtceu:tiny_bone_dust', null, 0.01, null)
+	event.fertilizer('gtceu:small_bone_dust', null, 0.025, null)
+
+	event.fertilizer('gtceu:tiny_apatite_dust', null, 0.016, null)
+	event.fertilizer('gtceu:small_apatite_dust', null, 0.037, null)
+	event.fertilizer('gtceu:apatite_dust', null, 0.15, null)
+
+	event.fertilizer('gtceu:tiny_tricalcium_phosphate_dust', null, 0.016, null)
+	event.fertilizer('gtceu:small_tricalcium_phosphate_dust', null, 0.037, null)
+	event.fertilizer('gtceu:tricalcium_phosphate_dust', null, 0.15, null)
+
+	event.fertilizer('gtceu:tiny_phosphate_dust', null, 0.02, null)
+	event.fertilizer('gtceu:small_phosphate_dust', null, 0.05, null)
+	event.fertilizer('gtceu:phosphate_dust', null, 0.2, null)
+
 	event.fertilizer('gtceu:tiny_saltpeter_dust', 0.01, null, 0.038)
 	event.fertilizer('gtceu:small_saltpeter_dust', 0.025, null, 0.0875)
 	event.fertilizer('gtceu:saltpeter_dust', 0.10, null, 0.35)
 
-	event.fertilizer('gtceu:tiny_bone_dust', null, 0.01, null)
-	event.fertilizer('gtceu:small_bone_dust', null, 0.025, null)
+	event.fertilizer('gtceu:tiny_rock_salt_dust', null, null, 0.025)
+	event.fertilizer('gtceu:small_rock_salt_dust', null, null, 0.0625)
+	event.fertilizer('gtceu:rock_salt_dust', null, null, 0.25)
+
+	event.fertilizer('gtceu:tiny_potassium_sulfate_dust', null, null, 0.03)
+	event.fertilizer('gtceu:small_potassium_sulfate_dust', null, null, 0.075)
+	event.fertilizer('gtceu:potassium_sulfate_dust', null, null, 0.3)
+
+	event.fertilizer('gtceu:tiny_ammonium_chloride_dust', 0.03, null, null)
+	event.fertilizer('gtceu:small_ammonium_chloride_dust', 0.075, null, null)
+	event.fertilizer('gtceu:ammonium_chloride_dust', 0.3, null, null)
+
+
 }
 
 


### PR DESCRIPTION
## What is the new behavior?
Adds tfc fertilizer values for various phosphorus, potassium and nitrogen compounds

## Outcome
- Apatite dust - 15% phosphorus 
- Tricalcium Phosphate dust - 15% phosphorus
- Phosphate dust - 20% phosphorus
- Rock Salt dust - 25% potassium
- Potassium Sulfate dust - 30% potassium
- Ammonium Chloride dust - 30% nitrogen

_Small dusts have 1/4 of percentage, tiny dusts have ~1/9 - 1/10 of percentage_

## Additional Information
In case this breaks balance of fertilizers required changes can be made.
_Originally sylvite was planned to be included, but sylvite dust already has 50% potassium, which is reasonable increase from rock salt considering it originates from the beneath and is harder to get_