### PR TITLE
add checkmark to cooked meat preservation quest for meats that are for some reason not included

### DIFF
--- a/config/ftbquests/quests/chapters/queststfc_tips.snbt
+++ b/config/ftbquests/quests/chapters/queststfc_tips.snbt
@@ -1117,6 +1117,7 @@
 							"ftbfiltersystem:filter": "or(item(tfc:wrought_iron_grill)item(firmalife:cured_oven_top))"
 						}
 					}
+					optional_task: true
 					title: "{quests.tfg_tips.cook_meat.task.2}"
 					type: "item"
 				}


### PR DESCRIPTION

adds a checkmark to complete the Meat Preservation: Cooking quest as fish are for some reason not included in the filter

an alternative solution could be to add oven baked fish in separately, but that sounds like a pain for very little gain.

Federation President Bravo