### PR TITLE
Hot-fix for tfc gurman foods not giving back bowls

### DIFF
--- a/kubejs/server_scripts/tfc_gurman/fix_bowls.js
+++ b/kubejs/server_scripts/tfc_gurman/fix_bowls.js
@@ -1,0 +1,45 @@
+let bowls = [
+    "porridge",
+    "porridge_with_honey",
+    "porridge_with_fruits",
+    "pasta_with_adjika",
+    "zama",
+    "mamaliga",
+    "fried_rice",
+    "curry",
+    "pho",
+    "hummus",
+    "greek_salad",
+    "tzatziki",
+    "goulash",
+    "risotto",
+    "biryani",
+    "ratatouille",
+    "dolma",
+    "schi",
+    "cooked_rice_noodles",
+    "ramen_with_chevon",
+    "solyanka",
+    "kimchi",
+    "ramen_with_beef",
+    "ramen_with_camelidae",
+    "pasta_cabonara",
+    "bouillabaisse",
+    "spaghetti_bolognese",
+    "ramen_with_bacon",
+    "okroshka",
+    "adjika",
+    "cooked_pasta",
+    "borscht"
+]
+
+for (let i=0; i<bowls.length; i++){
+    bowls[i] = "tfc_gurman:"+bowls[i]
+}
+
+ItemEvents.foodEaten( event => {
+    
+    if(bowls.includes("tfc_gurman:borscht")) {
+        event.player.give(Item.of("tfc:ceramic/bowl",1))
+    }
+})


### PR DESCRIPTION
missing feature: tfc_gurman foods returning bowls

## What is the new behavior?
Hot-fix for bowls not being returned when eating tfc_gurman foods (https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/2389)

## Implementation Details
using cube js `foodEaten` event and a list of affected foods

## Outcome
creamic bowls are returned to the player, sadly ignoring the original type of bowl used to obtain the food

Addresses (sadly not fixes): #2389 

## Potential Compatibility Issues
As mentioned, not returning the correct bowl type, how to work this in is sadly beyond me, tho I'd like to hear how it'd be done.

P.S. I'm aware its the most stupid way to implement this and `foodEaten` is not best practice

Discord: @BlackLightDragon (yes its the same)