### PR TITLE
Removed cleanroom requirement from level emitter

### DIFF
--- a/kubejs/server_scripts/ae2/recipes.js
+++ b/kubejs/server_scripts/ae2/recipes.js
@@ -1153,7 +1153,6 @@ const registerAE2Recipes = (event) => {
 		.circuit(1)
 		.duration(20)
 		.EUt(480)
-		.cleanroom(CleanroomType.CLEANROOM)
 		.addMaterialInfo(true)
 
 	// Storage Bus


### PR DESCRIPTION
Remove the cleanroom requirement from the AE2 level emitter, as it can be crafted in a crafting table as well.