### PR TITLE
change energy acceptor to use a machine hull instead of a converter, because it doesn't convert!

### DIFF
--- a/kubejs/server_scripts/ae2/recipes.js
+++ b/kubejs/server_scripts/ae2/recipes.js
@@ -652,7 +652,7 @@ const registerAE2Recipes = (event) => {
 
 	// Energy Acceptor
 	event.recipes.gtceu.assembler('tfg:ae2/energy_acceptor')
-		.itemInputs('5x gtceu:silver_double_cable', 'gtceu:hv_1a_energy_converter', 'gtceu:annealed_copper_single_cable')
+		.itemInputs('5x gtceu:silver_double_cable', 'gtceu:hv_machine_hull', 'gtceu:annealed_copper_single_cable')
 		.itemOutputs('ae2:energy_acceptor')
 		.circuit(1)
 		.duration(520)


### PR DESCRIPTION
modifies the AE2 energy acceptor to use an HV machine hull in its recipe rather than an HV converter, as it doesn't really convert energies

simple logical qol change, plus it means people won't be confused when their cables spontaneously combust despite using a thing with a converter in its recipe lol

Federation President Bravo