### PR TITLE
Fix: Update ExtendedAE package name in InvTweaks exclusions

### DIFF
--- a/config/invtweaks-client.toml
+++ b/config/invtweaks-client.toml
@@ -90,7 +90,7 @@
 		sortRange = ""
 
 	[[sorting.containerOverrides]]
-		containerClass = "com.github.glodblock.epp.client.gui.*"
+		containerClass = "com.glodblock.github.extendedae.client.gui.*"
 		sortRange = ""
 
 	[[sorting.containerOverrides]]


### PR DESCRIPTION
## What is the new behavior?
MMB clicks currently don't work in ExtendedAE screens like the precise / threshold export buses. 

## Implementation Details
There's an entry in the InvTweaks exclusions, but it targets old package names. This PR updates that entry.

## Outcome
Fixes MMB clicks in ExtendedAE screens.