### PR TITLE
fixed oilburner smokestack assembler recipe

### DIFF
--- a/kubejs/server_scripts/railways/recipes.js
+++ b/kubejs/server_scripts/railways/recipes.js
@@ -319,7 +319,7 @@ const registerRailWaysRecipes = (event) => {
 	}).id('tfg:railways/shaped/smokestack_oilburner')
 
 	event.recipes.gtceu.assembler('tfg:railways/smokestack_oilburner')
-		.itemInputs('#forge:storage_blocks/charcoal', '6x #forge:plates/iron')
+		.itemInputs('#forge:storage_blocks/charcoal', '4x #forge:plates/iron')
 		.circuit(7)
 		.itemOutputs('railways:smokestack_oilburner')
 		.duration(200)


### PR DESCRIPTION
fixed the oilburner smokestack item using 6 plates in the assembler rather than the four it uses in the crafting table by changing it to use four plates.

Federation President Bravo