### PR TITLE
added locometal to Domum Ornamentum whitelist

### DIFF
--- a/kubejs/server_scripts/domum_ornamentum/tags.js
+++ b/kubejs/server_scripts/domum_ornamentum/tags.js
@@ -29,6 +29,7 @@ function registerDomumOrnamentumBlockTags(event) {
         "#tfc:colored_polished_alabaster",
         "#tfc:mud_bricks",
         "#forge:sandstone",
+        "#railways:locometal",
         //rnr shingles
         "rnr:wood/shingles/teak",
         "rnr:wood/shingles/cypress",


### PR DESCRIPTION
adds every variety of Locometal from Create: Steam N' Rails to the list of blocks that can be used for the various elements from Domum Ornamentum.

Federation President Bravo