### PR TITLE
removed sandworm spawning in the vanilla Minecraft desert biome

### DIFF
--- a/kubejs/server_scripts/tfg/mars/tags.mars.js
+++ b/kubejs/server_scripts/tfg/mars/tags.mars.js
@@ -335,6 +335,7 @@ function registerTFGMarsBiomeTags(event) {
 
 	event.add('sandworm_mod:can_spawn_sandworms', 'tfg:mars/martian_dunes')
 	event.add('sandworm_mod:can_spawn_sandworms', 'tfg:mars/martian_deep_desert')
+	event.remove('sandworm_mod:can_spawn_sandworms', 'minecraft:desert')
 
 	event.add('tfg:has_dark_sand_particles', 'tfg:mars/martian_dunes')
 	event.add('tfg:has_dark_sand_particles', 'tfg:mars/martian_deep_desert')


### PR DESCRIPTION
removes the sandworm's ability to spawn in the minecraft:desert biome, mainly for people using the 'redstone ready' superflat preset

Federation President Bravo
