### PR TITLE
Add vinegar as option for curdled milk crafting

### DIFF
--- a/kubejs/server_scripts/tfg/food/recipes.food.js
+++ b/kubejs/server_scripts/tfg/food/recipes.food.js
@@ -278,8 +278,8 @@ function registerTFGFoodRecipes(event) {
 
 		event.recipes.gtceu.mixer(`lactose_milk_vinegar_${item.id}`)
 			.circuit(1)
-			.inputFluids(Fluid.of(item.milk, 1000), Fluid.of('tfc:vinegar', 50))
-			.itemOutputs('1x gtceu:lactose_dust')
+			.inputFluids(Fluid.of(item.milk, 1000), Fluid.of('tfc:vinegar', 100))
+			.chancedOutput('gtceu:lactose_dust', 1000, 0)
 			.outputFluids(Fluid.of(item.curdled_fluid, 1000))
 			.duration(300)
 			.EUt(GTValues.VA[GTValues.LV])


### PR DESCRIPTION
This adds an earlier way to make cheese without relying on acetic acid. As vinegar is partially composed of acetic acid, and the recipe for homemade cheese using vinegar is realistic, that would be an useful and accurate recipe.

