### PR TITLE
Remove duplicate quest entry from ore processing chapter

### DIFF
--- a/config/ftbquests/quests/chapters/ore_processing.snbt
+++ b/config/ftbquests/quests/chapters/ore_processing.snbt
@@ -176,12 +176,6 @@
 			y: -13.0d
 		}
 		{
-			id: "138C7D4A61E2A77D"
-			linked_quest: "6B10099F3F0931B9"
-			x: 9.0d
-			y: -15.0d
-		}
-		{
 			id: "21670DA706D747EC"
 			linked_quest: "378F0AFCF95354B2"
 			x: 12.0d


### PR DESCRIPTION
## Outcome
Fixes: duplicate quest entry

## Additional Information
Old quest page:
<img width="2456" height="2008" alt="image" src="https://github.com/user-attachments/assets/fa9b55ca-e244-4f6c-a20d-6ec7bdd3a670" />

New quest page:
<img width="2456" height="2008" alt="image" src="https://github.com/user-attachments/assets/bb3218f4-8502-4efc-bebe-7d6f2a0c91ee" />

## Potential Compatibility Issues
Since there are [no references to this quest](https://github.com/search?q=repo%3ATerraFirmaGreg-Team%2FModpack-Modern%20138C7D4A61E2A77D&type=code), there should be no compatibility issues. 

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
InboundHalo