### PR TITLE
Inconsistency fix at recipes.coal.js

### DIFF
--- a/kubejs/server_scripts/tfg/powergen/recipes.coal.js
+++ b/kubejs/server_scripts/tfg/powergen/recipes.coal.js
@@ -3,7 +3,7 @@
 function registerTFGCoalRecipes(event) {
 
 	event.recipes.gtceu.coke_oven("tfg:poor_coal_to_coke")
-		.itemInputs('1x gtceu:poor_raw_coal')
+		.itemInputs('gtceu:poor_raw_coal')
 		.itemOutputs('1x gtceu:coke_gem')
 		.outputFluids(Fluid.of('gtceu:creosote', 500))
 		.duration(900)
@@ -12,13 +12,13 @@ function registerTFGCoalRecipes(event) {
 		.itemInputs('gtceu:raw_coal')
 		.itemOutputs('2x gtceu:coke_gem')
 		.outputFluids(Fluid.of('gtceu:creosote', 1000))
-		.duration(1800)
+		.duration(900)
 
 	event.recipes.gtceu.coke_oven("tfg:rich_coal_to_coke")
 		.itemInputs('gtceu:rich_raw_coal')
 		.itemOutputs('4x gtceu:coke_gem')
 		.outputFluids(Fluid.of('gtceu:creosote', 2000))
-		.duration(3600)
+		.duration(900)
 
 	event.recipes.gtceu.pyrolyse_oven("tfg:rich_coal_to_tar")
 		.itemInputs('3x gtceu:rich_raw_coal')


### PR DESCRIPTION
## What is the new behavior?
The old behaviour was that all the TFC coal ores had a recipe in the Coke Oven with a flat 900 tick time for any of the ores. Along with a duplicate recipe of the tfc:raw_coal that had both a 900 tick and a 1710 tick recipe that also gave too much creosote (2b instead of 1b). And tfc:poor_coal used 2x of its input item in the coke oven, which is inconsistent with the amount of coal gotten from smelting it.

<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/9c7607c2-d244-43c5-bdc5-2b332c989c5a" />

The new behaviour has the duplicate recipe removed, made the total amount of time per coke item consistent along outputs, and made the tfc:poor_coal's input recipe in the coke oven consistent with how much coal is produced in a furnace (1:1 in furnace instead of 2:1 in old coke oven)


## Outcome
Removed duplicate gtceu:raw_coal recipe with an odd time of 1710 ticks that caused one item have two recipes in the Coke Oven.
Changed recipe duration to reflect how much Coke is being made (ie 4x coke = 4x the base of 900 ticks, 45 seconds)
Changed tfc:poor_raw_coal recipe input to 1x tfc:poor_raw_coal instead of 2x tfc:poor_raw_coal to reflect the amount of Coal a piece or Poor Raw Coal gives in a furnace.


## Potential Compatibility Issues
None, all the TFC raw coal ores have a functional recipe, and normal minecraft coal can still be turned into coke.
Tested on local server

jurjen909