### PR TITLE
Hypertube Block --- Molecular Assembler recipe conflict fix (fixes #2703)

### DIFF
--- a/kubejs/server_scripts/create_hypertube/recipes.js
+++ b/kubejs/server_scripts/create_hypertube/recipes.js
@@ -6,6 +6,7 @@ function registerCreateHypertubeRecipes(event) {
 	event.recipes.gtceu.assembler('create_hypertube:hypertube')
 		.itemInputs('2x #forge:plates/stainless_steel', '4x ae2:quartz_glass')
 		.itemOutputs('8x create_hypertube:hypertube')
+		.circuit(1)
 		.EUt(GTValues.VA[GTValues.HV])
 		.duration(50)
 		.addMaterialInfo(true)


### PR DESCRIPTION
## What is the new behavior?
Literally adds 1 line of code to fix conflict between Hypertube Blocks and Molecular Assemblers.
Hypertube Block recipe now uses circuit 1

## Outcome
Fixes: #2703 

<sup><sub>the greatest and biggest pull request to ever exist</sub></sup>