### PR TITLE
adjustments to CC quests

### DIFF
--- a/config/ftbquests/quests/chapters/cc.snbt
+++ b/config/ftbquests/quests/chapters/cc.snbt
@@ -48,7 +48,7 @@
 					type: "item"
 				}
 			]
-			title: "{quests.comouter.disks.title}"
+			title: "{quests.computer.disks.title}"
 			x: 0.0d
 			y: 1.5d
 		}
@@ -137,7 +137,7 @@
 				"502B24C71210D52E"
 			]
 			dependency_requirement: "one_completed"
-			description: ["{quests.computer.turtle_advancdd.description}"]
+			description: ["{quests.computer.turtle_advanced.description}"]
 			id: "61B4EDA4365E1B7A"
 			tasks: [{
 				id: "4032A8D2000CDBAA"


### PR DESCRIPTION
Adjusted the quest layout in the CC chapter and added the corresponding description placeholders. As per #2682, the actual English text will be contributed separately to the Tools-Modern repository.