### PR TITLE
Consumes Wool Hat/ Silk Cowl

### DIFF
--- a/kubejs/server_scripts/diggerhelmet/recipes.js
+++ b/kubejs/server_scripts/diggerhelmet/recipes.js
@@ -46,11 +46,19 @@ function registerDiggerHelmetRecipes(event) {
 		C: '#forge:foils/rubber'
 	}).id('tfg:shaped/auto_drink_modifier_rubber')
 
-	event.recipes.tfc.damage_inputs_shapeless_crafting(
-		event.shapeless('diggerhelmet:silk_lining', ['tfcambiental:silk_cowl', '#forge:string', '#tfc:sewing_needles'])
-	).id('tfg:shapeless/diggerhelmet/silk_lining')
-
-	event.recipes.tfc.damage_inputs_shapeless_crafting(
-		event.shapeless('diggerhelmet:wool_lining', ['tfcambiental:wool_hat', '#forge:string', '#tfc:sewing_needles'])
-	).id('tfg:shapeless/diggerhelmet/wool_lining')
+	event.shapeless('diggerhelmet:silk_lining', [
+		'tfcambiental:silk_cowl', 
+		'#forge:string', 
+		'#tfc:sewing_needles'
+	])
+	.damageIngredient('#tfc:sewing_needles', 1)
+	.id('tfg:shapeless/diggerhelmet/silk_lining');
+	
+	event.shapeless('diggerhelmet:wool_lining', [
+		'tfcambiental:wool_hat', 
+		'#forge:string', 
+		'#tfc:sewing_needles'
+	])
+	.damageIngredient('#tfc:sewing_needles', 1)
+	.id('tfg:shapeless/diggerhelmet/wool_lining');
 }


### PR DESCRIPTION
## What is the new behavior?
Digger helmet linings should consume wool hat/ silk cowl, but it doesn't.

## Implementation Details
NIL

## Outcome
Makes it so that it consumes the silk cowl and wool hat instead of damaging them.

## Additional Information
NIL

## Potential Compatibility Issues
NIL

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
Inceit