### PR TITLE
Added beneath wood compat

### DIFF
--- a/kubejs/server_scripts/tfc/tags.js
+++ b/kubejs/server_scripts/tfc/tags.js
@@ -442,7 +442,7 @@ function registerTFCItemTags(event) {
         event.add(`tfg:hanging_sign/${metal}/hardwood`, global.AFC_HARDWOOD_TYPES.map(wood => `afc:wood/hanging_sign/${metal}/${wood}`))
         event.add(`tfg:hanging_sign/${metal}/softwood`, global.AFC_SOFTWOOD_TYPES.map(wood => `afc:wood/hanging_sign/${metal}/${wood}`))
         event.add(`tfg:hanging_sign/${metal}/hardwood`, `beneath:wood/hanging_sign/${metal}/warped`)
-        event.add(`tfg:hanging_sign/${metal}/hardwood`, `beneath:wood/hanging_sign/${metal}/crimson`)
+        event.add(`tfg:hanging_sign/${metal}/softwood`, `beneath:wood/hanging_sign/${metal}/crimson`)
     })
 }
 


### PR DESCRIPTION
## What is the new behavior?
Beneath hanging signs does not have support for recycling. 
## Implementation Details
NIL

## Outcome
Added recycling support.

## Additional Information
NIL

## Potential Compatibility Issues
Is beneath wood considered hardwood? I'd assume that it is, since both types of wood gives tannin. But there is a lack of crushing recipe for beneath wood to hardwood dust too...

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
Inceit