### PR TITLE
re-added glass dust recipe for glass tubes

### DIFF
--- a/kubejs/server_scripts/tfg/ores_and_materials/recipes.quartzes.js
+++ b/kubejs/server_scripts/tfg/ores_and_materials/recipes.quartzes.js
@@ -68,7 +68,7 @@ function registerTFGQuartzRecipes(event) {
 	// Empty Jar
 	event.recipes.gtceu.alloy_smelter('tfg:jar_alloying')
 		.itemInputs('#tfc:glass_batches_tier_2')
-		.notConsumable('gtceu:ball_casting_mold')
+		.notConsumable('tfg:lamp_casting_mold')
 		.itemOutputs('tfc:empty_jar')
 		.duration(100)
 		.EUt(2)
@@ -76,7 +76,7 @@ function registerTFGQuartzRecipes(event) {
 
 	event.recipes.gtceu.alloy_smelter('tfg:jar_alloying_dust')
 		.itemInputs('#forge:dusts/glass')
-		.notConsumable('gtceu:ball_casting_mold')
+		.notConsumable('tfg:lamp_casting_mold')
 		.itemOutputs('tfc:empty_jar')
 		.duration(100)
 		.EUt(2)


### PR DESCRIPTION
fixed a recipe conflict between jars and glass tubes to allow glass tubes to be made in the alloy smelter with glass dust again by changing jars to use the lamp casting mold rather than the ball one.

Federation President Bravo