### PR TITLE
Fix swapped tags for rosin saplings and leaves

### DIFF
--- a/kubejs/server_scripts/afc/tags.js
+++ b/kubejs/server_scripts/afc/tags.js
@@ -69,7 +69,6 @@ const registerAFCItemTags = (event) => {
 	event.add("tfg:rosin_logs", "#tfc:white_cedar_logs")
 	event.add("tfg:rosin_logs", "#tfc:douglas_fir_logs")
 
-	// swapped tags around (Add saplings to the "rosin_saplings" tag, Add leaves to the "rosin_leaves" tag)
     event.add("tfg:rosin_saplings", 'tfc:wood/sapling/aspen')
     event.add("tfg:rosin_saplings", 'afc:wood/sapling/coast_spruce')
     event.add("tfg:rosin_saplings", 'tfc:wood/sapling/spruce')


### PR DESCRIPTION
## What is the new behavior?
The tags tfg:rosin_saplings and tfg:rosin_leaves now contain the correct items. Previously, the lists were swapped (saplings were in the leaves tag, and leaves were in the sapling tag).

## Implementation Details
Modified kubejs/server_scripts/afc/tags.js to swap the item lists:
- tfg:rosin_saplings now contains the list of sapling items.
- tfg:rosin_leaves now contains the list of leaf items.

## Outcome
Fixes #2836
<img width="410" height="417" alt="Screenshot 2026-01-24 231232" src="https://github.com/user-attachments/assets/783986f9-4d35-437f-a1bb-f2bb7d4e48a6" />
<img width="388" height="409" alt="Screenshot 2026-01-24 231237" src="https://github.com/user-attachments/assets/bf148285-07c3-4f6a-ae9f-5f579a6dd143" />


**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
TanJeeSchuan