### PR TITLE
Added assembler recipe for framed cube

### DIFF
--- a/kubejs/server_scripts/framed_blocks/recipes.js
+++ b/kubejs/server_scripts/framed_blocks/recipes.js
@@ -385,6 +385,13 @@ const registerFramedBlocksRecipes = (event) => {
 		A: '#minecraft:planks',
 		B: '#forge:rods/wooden'
 	}).id('framedblocks:framed_cube')
+	
+	event.recipes.gtceu.assembler('tfg:assembler/framedblocks/framed_cube')
+		.itemInputs('4x #minecraft:planks', '4x #forge:rods/wooden')
+		.circuit(8)
+		.itemOutputs('framedblocks:framed_cube')
+		.duration(40)
+		.EUt(GTValues.VA[GTValues.ULV])
 
 	// Framed Fence
 	event.shaped('3x framedblocks:framed_fence', [


### PR DESCRIPTION
## What is the new behavior?
Assembler framed cube

## Implementation Details
Kept it at a 4:4 ratio rather than 1 stick 1 planks = 1 block. not sure if this is consistent with assembler generally. made sure the circuit wasnt used for anything else with either resource

## Outcome
framed blocks now able to be automated

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
cooliecurveball