### PR TITLE
Update recipes.dyes.js

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.dyes.js
+++ b/kubejs/server_scripts/tfc/recipes.dyes.js
@@ -156,4 +156,49 @@ function registerTFCDyeRecipes(event) {
 	})
 
 	//#endregion
+
+	//#region Dye mixing
+    const dyeMixes = [
+        // input 1
+        [
+            'black', 'white', 'white',
+            'white', 'blue', 'blue',
+            'purple', 'white', 'red',
+            'orange', 'yellow'
+        ],
+        // input 2
+        [
+            'light_gray', 'gray', 'green',
+            'blue', 'green', 'red',
+            'pink', 'red', 'yellow',
+            'black', 'blue'
+        ],
+        // output
+        [
+            'gray', 'light_gray', 'light_green',
+            'light_blue', 'cyan', 'purple',
+            'magenta', 'pink', 'orange',
+            'brown', 'green'
+        ]
+    ]
+
+    for (let i = 0; i < dyeMixes[2].length; i++) {
+        if (!Fluid.exists(`tfc:${dyeMixes[0][i]}_dye`) ||
+            !Fluid.exists(`tfc:${dyeMixes[1][i]}_dye`) ||
+            !Fluid.exists(`tfc:${dyeMixes[2][i]}_dye`)
+        ) continue
+
+        event.recipes.gtceu.mixer(`mixer_dye_${dyeMixes[2][i]}`)
+            .inputFluids(
+                Fluid.of(`tfc:${dyeMixes[0][i]}_dye`, 144),
+                Fluid.of(`tfc:${dyeMixes[1][i]}_dye`, 144)
+            )
+            .outputFluids(
+                Fluid.of(`tfc:${dyeMixes[2][i]}_dye`, 288)
+            )
+            .duration(20)
+            .EUt(8)
+    }
+
+    //#endregion
 }


### PR DESCRIPTION
## What is the new behavior?
added base 9 dye mixing as fluids + 2 custom ones as stated in the issue #2818

## Implementation Details
see issue

## Outcome
11 new mixer recipes for fluid dyes

## Additional Information
the dye mixing is automated so you can add more cobinations by just adding elements in the array, moste things are commented so it should be fine 

## Potential Compatibility Issues
should be non although idk if i didnt fuck up the push

OLOXtheHusar