### PR TITLE
bugfix: Aged alcohols now are drinkable when player water is full

### DIFF
--- a/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_beer.json
+++ b/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_beer.json
@@ -1,0 +1,14 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "ingredient": "tfcagedalcohol:aged_beer",
+  "thirst": 15,
+  "intoxication": 2000,
+  "may_drink_when_full": true,
+  "effects": [
+    {
+      "type": "minecraft:absorption",
+      "duration": 6400,
+      "amplifier": 1
+    }
+  ]
+}

--- a/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_cider.json
+++ b/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_cider.json
@@ -1,0 +1,14 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "ingredient": "tfcagedalcohol:aged_cider",
+  "thirst": 15,
+  "intoxication": 2000,
+  "may_drink_when_full": true,
+  "effects": [
+    {
+      "type": "minecraft:speed",
+      "duration": 6400,
+      "amplifier": 0
+    }
+  ]
+}

--- a/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_corn_whiskey.json
+++ b/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_corn_whiskey.json
@@ -1,0 +1,13 @@
+{
+  "ingredient": "tfcagedalcohol:aged_corn_whiskey",
+  "thirst": 15,
+  "intoxication": 2000,
+  "may_drink_when_full": true,
+  "effects": [
+    {
+      "type": "minecraft:haste",
+      "duration": 6400,
+      "amplifier": 0
+    }
+  ]
+}

--- a/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_mead.json
+++ b/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_mead.json
@@ -1,0 +1,13 @@
+{
+  "ingredient": "tfcagedalcohol:aged_mead",
+  "thirst": 15,
+  "intoxication": 2000,
+  "may_drink_when_full": true,
+  "effects": [
+    {
+      "type": "minecraft:regeneration",
+      "duration": 6400,
+      "amplifier": 0
+    }
+  ]
+}

--- a/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_rum.json
+++ b/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_rum.json
@@ -1,0 +1,13 @@
+{
+  "ingredient": "tfcagedalcohol:aged_rum",
+  "thirst": 15,
+  "intoxication": 2000,
+  "may_drink_when_full": true,
+  "effects": [
+    {
+      "type": "minecraft:speed",
+      "duration": 3200,
+      "amplifier": 1
+    }
+  ]
+}

--- a/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_rye_whiskey.json
+++ b/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_rye_whiskey.json
@@ -1,0 +1,13 @@
+{
+  "ingredient": "tfcagedalcohol:aged_rye_whiskey",
+  "thirst": 15,
+  "intoxication": 2000,
+  "may_drink_when_full": true,
+  "effects": [
+    {
+      "type": "minecraft:haste",
+      "duration": 6400,
+      "amplifier": 0
+    }
+  ]
+}

--- a/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_sake.json
+++ b/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_sake.json
@@ -1,0 +1,13 @@
+{
+  "ingredient": "tfcagedalcohol:aged_sake",
+  "thirst": 15,
+  "intoxication": 2000,
+  "may_drink_when_full": true,
+  "effects": [
+    {
+      "type": "minecraft:resistance",
+      "duration": 6400,
+      "amplifier": 0
+    }
+  ]
+}

--- a/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_vodka.json
+++ b/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_vodka.json
@@ -1,0 +1,13 @@
+{
+  "ingredient": "tfcagedalcohol:aged_vodka",
+  "thirst": 15,
+  "intoxication": 2000,
+  "may_drink_when_full": true,
+  "effects": [
+    {
+      "type": "minecraft:resistance",
+      "duration": 3200,
+      "amplifier": 1
+    }
+  ]
+}

--- a/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_whiskey.json
+++ b/kubejs/data/tfcagedalcohol/tfc/drinkables/aged_whiskey.json
@@ -1,0 +1,13 @@
+{
+  "ingredient": "tfcagedalcohol:aged_whiskey",
+  "thirst": 15,
+  "intoxication": 2000,
+  "may_drink_when_full": true,
+  "effects": [
+    {
+      "type": "minecraft:haste",
+      "duration": 3200,
+      "amplifier": 1
+    }
+  ]
+}


### PR DESCRIPTION
## Outcome
Makes aged alcohols drinkable when player water is full, like other drinkables that give buffs and like the latest aged alcohols mod code does