### PR TITLE
Weird ass bug potential fix

### DIFF
--- a/kubejs/server_scripts/tfc/data.js
+++ b/kubejs/server_scripts/tfc/data.js
@@ -110,9 +110,9 @@ const registerTFCFertilizers = (event) => {
 	event.fertilizer('gtceu:small_ammonium_chloride_dust', 0.075, null, null)
 	event.fertilizer('gtceu:ammonium_chloride_dust', 0.3, null, null)
 	
-	event.fertilizer('tfc:pure_nitrogen', 1, null, null)
-	event.fertilizer('tfc:pure_phosphorus', null, 1, null)
-	event.fertilizer('tfc:pure_potassium', null, null, 1)
+	event.fertilizer('tfc:pure_nitrogen', 1.0, null, null)
+	event.fertilizer('tfc:pure_phosphorus', null, 1.0, null)
+	event.fertilizer('tfc:pure_potassium', null, null, 1.0)
 
 
 }


### PR DESCRIPTION
Nitrogen and Phosphorus werent working (fertilizer values remain at 10%) but potassium was. Only difference is where the variable is, and what it was followed by. Potassium worked potentially because it didnt have a comma?? This might fix it????? this bug should not occur but it does. i am an evil developer that does not test my simple code