### PR TITLE
Add TiCl and Nerfs to energy

### DIFF
--- a/kubejs/server_scripts/tfg/powergen/nuclear/recipes.nuclear.js
+++ b/kubejs/server_scripts/tfg/powergen/nuclear/recipes.nuclear.js
@@ -1405,4 +1405,20 @@ function registerTFGNuclearRecipes(event) {
 		.duration(20*14)
 		.EUt(GTValues.VA[GTValues.EV])
 
+	//#region TiCl4 Small Reactor Coolant
+
+	event.recipes.gtceu.gas_pressurizer('tfg:super_critical_co2')
+		.inputFluids(Fluid.of('gtceu:carbon_dioxide', 1000))
+		.outputFluids(Fluid.of('tfg:supercritical_co2', 10))
+		.circuit(1)
+		.duration(20*58)
+		.EUt(GTValues.VA[GTValues.HV])
+
+	event.recipes.gtceu.chemical_reactor('tfg:ticl_doped')
+		.inputFluids(Fluid.of('gtceu:titanium_tetrachloride', 1000), Fluid.of('tfg:supercritical_co2', 1000))
+		.outputFluids(Fluid.of('tfg:ticl4_doped_supercritical_co2', 1000))
+		.circuit(1)
+		.duration(20*4)
+		.EUt(GTValues.VA[GTValues.IV])
+
 }

--- a/kubejs/server_scripts/tfg/powergen/recipes.power_gen_balance.js
+++ b/kubejs/server_scripts/tfg/powergen/recipes.power_gen_balance.js
@@ -13,7 +13,7 @@ function registerTFGPowerGenBalance(event) {
     //#endregion
 
     //#region Nerf/Removed
-/* COMMENT OUT UNTIL WE WANT TO ENABLE THE NERF
+
 	event.remove({ id: 'gtceu:gas_turbine/benzene' })
 	event.recipes.gtceu.gas_turbine('tfg:benzene')
 		.inputFluids(Fluid.of('gtceu:benzene', 1))
@@ -29,7 +29,15 @@ function registerTFGPowerGenBalance(event) {
 		.EUt(-32)
         .dimension('minecraft:overworld')
 		.dimension('minecraft:the_nether')
-*/
+
+	event.remove({ id: 'gtceu:combustion_generator/naphtha' })
+	event.recipes.gtceu.combustion_generator('tfg:naphtha')
+		.inputFluids(Fluid.of('gtceu:naphtha', 1))
+		.duration(20*0.1)
+		.EUt(-32)
+        .dimension('minecraft:overworld')
+		.dimension('minecraft:the_nether')
+
     // Remove Light fuel ability as a fuel
 
 	event.remove({ id: 'gtceu:combustion_generator/sulfuric_light_fuel' })


### PR DESCRIPTION
-Add recipes for TiCl Small Reactor Coolant
-Push the nerf to Benzene (64%), Nitrobenzene (75%) and Naphtha (-400%)