### PR TITLE
Workaround for server overrides sometimes not applying to serverpack exports.

### DIFF
--- a/pakku.json
+++ b/pakku.json
@@ -10,13 +10,19 @@
         "kubejs",
         "tacz",
         "!kubejs/probe/**",
-        "!kubejs/assets/**"
+        "!kubejs/assets/**",
+        "!defaultconfigs/tfc-server.toml",
+        "!config/ftbbackups2.json",
+        "!defaultconfigs/ftbranks/ranks.snbt"
     ],
     "server_overrides": [
     ],
     "client_overrides": [
         "resourcepacks",
-        "kubejs/assets/**"
+        "kubejs/assets/**",
+        "defaultconfigs/tfc-server.toml",
+        "config/ftbbackups2.json",
+        "defaultconfigs/ftbranks/ranks.snbt"
     ],
     "projects": {
         "ambient-environment": {


### PR DESCRIPTION
Firstly, I looked at the pakku source, and it's a race condition between the "Manual overrides" process and the normal file inclusion. Both run as async tasks, both try to include the config files in the serverpack, whoever does so last wins.
I left them a bug report: https://github.com/juraj-hrivnak/Pakku/issues/120 
More info there.

Until Pakku fixes the issue, there's very little we can do to fix this properly. But we can check if the problem occurred by adding this to build.yaml, and if the problem ocurred it fails the build automatically. It checks the md5 hash of the included `tfc-server.toml` against the md5 hash of the `.pakku/server-overrides/defaultconfigs/tfc-server.toml`

The bug actually affects all 3 files but we only need to check one of them.
```
defaultconfigs/tfc-server.toml
config/ftbbackups2.json
defaultconfigs/ftbranks/ranks.snbt
```
These are all files that get copied over both in the normal process and in the Manual Override process. The process that finishes last gets the final word. There's no way to enforce or prioritize only one of those in any way I can see. We _could_ remove them entirely from the project root and include different versions in client-overrides and server-overrides only, but that's ugly and the other devs wouldn't know where the hell tfc-server.toml went or why.

If you're happy with it we can merge this PR into dev and it'll automatically trigger the CI workflow to test the server override verification. Not sure how to test that locally.

---

Secondarily, we have our own bug, or at least misunderstanding in the json. It's not actually hurting anything but it seeds confusion: We have this in pakku.json:
```
    "server_overrides": [
        "forge-auto-install.txt",
        "generate_auto_installation_file.bat",
        "minecraft_server.jar",
        "server.properties",
        "server_starter.conf",
        "server-icon.png",
        "start_server.bat",
        "README.md"  
    ],
```
But this doesn't do anything, because none of those files exist in the project root. Server_overrides _only_ matches against project root files, and none of these match, so none of these get included _via this path_. However, they _do_ get included via the "Manual Overrides" path that just walks the `.pakku/server-overrides/` folder for any files, but that's not something that you can write a config for at all, that's just always there. So all these listed files got included but not because we wrote them here.

I deleted them and ran pakku export and they were all there in the serverpack zip.
However this is not related to the actual problems we saw, it's just confusing dead config.