### PR TITLE
Add shapeless recipe to glowing dye

### DIFF
--- a/kubejs/server_scripts/minecraft/recipes.js
+++ b/kubejs/server_scripts/minecraft/recipes.js
@@ -1001,6 +1001,12 @@ const registerMinecraftRecipes = (event) => {
 		.itemOutputs('minecraft:glow_ink_sac')
 		.duration(40)
 		.EUt(GTValues.VA[GTValues.LV])
+
+	event.shapeless("minecraft:glow_ink_sac", [
+      "minecraft:glowstone_dust",
+      "minecraft:glowstone_dust",
+      "#forge:dyes"])
+    .id("tfg:shapeless/glow_ink_sac");
 		
 	//#endregion
 


### PR DESCRIPTION
## What is the new behavior?
Added a shapeless recipe to glowing dye. 2 glowstone dust and any dye will give 1 glowing dye. This is to let players gain access to glowing dye which is useful for use on signs.

## Implementation Details
Modified recipes.js in kubejs/server_scripts/minecraft/recipes.js

Discord: @sakura.kitsurugi