### PR TITLE
Update steam bloomery quest description 2/2

### DIFF
--- a/config/ftbquests/quests/chapters/questssteam_age.snbt
+++ b/config/ftbquests/quests/chapters/questssteam_age.snbt
@@ -635,7 +635,11 @@
 		}
 		{
 			dependencies: ["46FA9DD4755A5548"]
-			description: ["{quests.steam_age.steam_bloomery.desc}"]
+			description:[
+							"{quests.steam_age.steam_bloomery.desc.1}"
+							"{@pagebreak}"
+							"{quests.steam_age.steam_bloomery.desc.2}"
+						]
 			icon: "tfg:steam_bloomery"
 			id: "0805CCABC8E7F6CF"
 			optional: true


### PR DESCRIPTION
## What is the new behavior?
-Clarified steam bloomery repice time inconsistency between JEI and in action within steam bloomery quest.

## Implementation Details
-added page to steam bloomery quest and description of the clarification on second page.

-Tldr:steam bloomery shows differend time in JEI than when used in world cause like most other steam multiblocks its 50% slower  but no where it is mentioned and it cannot be directly deduced as steam bloomery JEI shows only steam bloomery as valid blocks to craft steam bloomery repicies

-alternatives: clarification can be done without adding page, but it would also make steam bloomery description longest single page description within steam age. alternatively standardization between the JEI repice time within in action repice time of steam bloomery would resolve the inconsistency (over my skill level). or none.

## Outcome
-added extra information to steam bloomery description

## Additional Information
-

## Potential Compatibility Issues
most likely none unless weve fucked up somehow

Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role
seele_ (though i feel like its fairly inconsequential change to deserve contributor + got some from help from x.kato)