### PR TITLE
Workaround to allow quark suit to breathe in space

### DIFF
--- a/kubejs/server_scripts/tfg/equipment/tags.equipment.js
+++ b/kubejs/server_scripts/tfg/equipment/tags.equipment.js
@@ -31,23 +31,11 @@ function registerTFGEquipmentItemTags(event) {
 	event.add('gtceu:ppe_armor', '#ad_astra:space_suit_items')
 	event.add('minecraft:trimmable_armor', '#ad_astra:space_suit_items')
 
-	event.add('ad_astra:space_suit_items', 'gtceu:quarktech_helmet')
-	event.add('ad_astra:space_suit_items', 'gtceu:quarktech_chestplate')
-	event.add('ad_astra:space_suit_items', 'gtceu:advanced_quarktech_chestplate')
-	event.add('ad_astra:space_suit_items', 'gtceu:quarktech_leggings')
-	event.add('ad_astra:space_suit_items', 'gtceu:quarktech_boots')
-
-	event.add('ad_astra:freeze_resistant_armor', 'gtceu:quarktech_helmet')
-	event.add('ad_astra:freeze_resistant_armor', 'gtceu:quarktech_chestplate')
-	event.add('ad_astra:freeze_resistant_armor', 'gtceu:advanced_quarktech_chestplate')
-	event.add('ad_astra:freeze_resistant_armor', 'gtceu:quarktech_leggings')
-	event.add('ad_astra:freeze_resistant_armor', 'gtceu:quarktech_boots')
-	
-	event.add('ad_astra:heat_resistant_armor', 'gtceu:quarktech_helmet')
-	event.add('ad_astra:heat_resistant_armor', 'gtceu:quarktech_chestplate')
-	event.add('ad_astra:heat_resistant_armor', 'gtceu:advanced_quarktech_chestplate')
-	event.add('ad_astra:heat_resistant_armor', 'gtceu:quarktech_leggings')
-	event.add('ad_astra:heat_resistant_armor', 'gtceu:quarktech_boots')
+	event.add('ad_astra:space_resistant_armor', 'gtceu:quarktech_helmet')
+	event.add('ad_astra:space_resistant_armor', 'gtceu:quarktech_chestplate')
+	event.add('ad_astra:space_resistant_armor', 'gtceu:advanced_quarktech_chestplate')
+	event.add('ad_astra:space_resistant_armor', 'gtceu:quarktech_leggings')
+	event.add('ad_astra:space_resistant_armor', 'gtceu:quarktech_boots')
 
 	event.add('tfc:deals_crushing_damage', '#forge:tools/mining_hammers')
 	event.add('tfc:deals_crushing_damage', '#minecraft:shovels')


### PR DESCRIPTION
## What is the new behavior?
Allows quark suit to breathe in space. Does not consume oxygen.

## Implementation Details
Added quark suit to ad_astra:space_resistant_armor

## Additional Information
This is temporary until we get modular armor.
Space Resistant Armor is also resistant to hot and cold.
Workaround for #1751