### PR TITLE
Fixed exception spam

### DIFF
--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -511,7 +511,10 @@ const registerTooltips = (event) => {
 		let keyToRemove = text.find(tip => tip.toString().indexOf(sculptorKey) != -1);
 		let indexOf = text.findIndex(tip => tip.toString().indexOf(sculptorKey) != -1);
 
-		text.remove(keyToRemove);
-		text.add(indexOf, Text.translate("tfg.tooltip.tool_behaviour.silk_ice"));
+		if(indexOf != -1)
+		{
+			text.remove(keyToRemove);
+			text.add(indexOf, Text.translate("tfg.tooltip.tool_behaviour.silk_ice"));
+		}
 	})
 }


### PR DESCRIPTION
## What is the new behavior?
Fixes unticketed bug where the Sculptor+ tooltip would throw exceptions multiple times, reducing framerate

## Implementation Details
Just dont go out of bounds if index is out of bounds

## Outcome
yknow, its fixed.

## Additional Information

<img width="646" height="142" alt="image" src="https://github.com/user-attachments/assets/c62b3a01-aab4-4a4a-9aff-a6e74e81d949" />

## Potential Compatibility Issues
Meow