### PR TITLE
Fix NPE when foxes eat food with return item

### DIFF
--- a/kubejs/startup_scripts/tfg/items.food.js
+++ b/kubejs/startup_scripts/tfg/items.food.js
@@ -18,8 +18,11 @@ function registerTFGFoodItems(event) {
 		.translationKey('item.tfg.food.meal_bag')
 		.food(food => food.hunger(6).saturation(3)
 			.eaten(ctx => {
-				ctx.player.give('tfg:used_foil_pack')
-			}))
+				if (ctx.player) {
+					ctx.player.give('tfg:used_foil_pack')
+				}
+			})
+		)
 		.texture('tfg:item/food/meal_bag')
 		.tag('tfc:foods')
 		.tag('tfg:space_food')
@@ -65,8 +68,11 @@ function registerTFGFoodItems(event) {
 			.tag('tfg:space_food')
 			.food(food => food.hunger(4).saturation(1)
 				.eaten(ctx => {
-					ctx.player.give('tfg:used_foil_pack')
-				}))
+					if (ctx.player) {
+						ctx.player.give('tfg:used_foil_pack')
+					}
+				})
+			)
 	})
 
 	// Calorie paste
@@ -74,8 +80,11 @@ function registerTFGFoodItems(event) {
 		.translationKey('item.tfg.food.calorie_paste')
 		.food(food => food.hunger(8).saturation(5)
 			.eaten(ctx => {
-				ctx.player.give('tfg:used_foil_pack')
-			}))
+				if (ctx.player) {
+					ctx.player.give('tfg:used_foil_pack')
+				}
+			})
+		)
 		.texture('tfg:item/food/calorie_paste')
 		.tag('tfc:foods')
 		.tag('tfg:space_food')
@@ -285,8 +294,11 @@ function registerTFGFoodItems(event) {
 		.food(food => food.hunger(1).saturation(1)
 			.effect('minecraft:hunger', 100, 0, 1)
 			.eaten(ctx => {
-				ctx.player.give('minecraft:stick')
-			}))
+				if (ctx.player) {
+					ctx.player.give('minecraft:stick')
+				}
+			})
+		)
 		.tag('tfc:foods')
 		.tag('tfc:foods/meats')
 		.tag('tfc:foods/raw_meats')
@@ -296,8 +308,11 @@ function registerTFGFoodItems(event) {
 		.parentModel('tfg:item/food/cooked_stickastackatick')
 		.food(food => food.hunger(2).saturation(2)
 			.eaten(ctx => {
-				ctx.player.give('minecraft:stick')
-			}))
+				if (ctx.player) {
+					ctx.player.give('minecraft:stick')
+				}
+			})
+		)
 		.tag('tfc:foods')
 		.tag('tfc:foods/meats')
 		.tag('tfc:foods/cooked_meats')
@@ -374,7 +389,9 @@ function registerTFGFoodItems(event) {
 		.food(food => {
 			food.effect('tfg:cooling', 100, 0, 1)
 			food.eaten(ctx => {
-				ctx.player.give('tfc:ceramic/bowl')
+				if (ctx.player) {
+					ctx.player.give('tfc:ceramic/bowl')
+				}
 			})
 		})
 
@@ -464,8 +481,11 @@ function registerTFGFoodItems(event) {
 		.texture('tfg:item/food/slice_of_cheese')
 		.food(food => food.hunger(4).saturation(2)
 			.eaten(ctx => {
-				ctx.player.give(ChemicalHelper.get(TagPrefix.foil, GTMaterials.Polyethylene, 1))
-			}))
+				if (ctx.player) {
+					ctx.player.give(ChemicalHelper.get(TagPrefix.foil, GTMaterials.Polyethylene, 1))
+				}
+			})
+		)
 		.tag('tfc:foods/usable_in_jam_sandwich')
 		.tag('tfc:foods/usable_in_jam_sandwich_2')
 		.tag('tfc:foods/usable_in_sandwich')
@@ -486,8 +506,11 @@ function registerTFGFoodItems(event) {
 		.texture('tfg:item/food/raw_instant_mac')
 		.food(food => food.hunger(2).saturation(2)
 			.eaten(ctx => {
-				ctx.player.give('create:cardboard')
-			}))
+				if (ctx.player) {
+					ctx.player.give('create:cardboard')
+				}
+			})
+		)
 	    .tag('tfc:foods');
 
 	event.create('tfg:food/cooked_instant_mac')
@@ -495,8 +518,11 @@ function registerTFGFoodItems(event) {
 		.texture('tfg:item/food/cooked_instant_mac')
 		.food(food => food.hunger(4).saturation(4)
 			.eaten(ctx => {
-				ctx.player.give('create:cardboard')
-			}))
+				if (ctx.player) {
+					ctx.player.give('create:cardboard')
+				}
+			})
+		)
 	    .tag('tfc:foods');
 
 	//#region Spices


### PR DESCRIPTION
## What is the new behavior?
Fixes #3274 for mealbags, cryo fruit bags, calorie paste, stickastackaticks, instant mac, ice soup, and slice of cheese

## Implementation Details
Checks if it's a player eating the item. If not, it just deletes the return item.