### PR TITLE
Add #forge tags to fluids we want to replace

### DIFF
--- a/kubejs/server_scripts/tfg/tags.js
+++ b/kubejs/server_scripts/tfg/tags.js
@@ -207,6 +207,14 @@ const registerTFGFluidTags = (event) => {
 	// Platline tags
 	event.add('tfg:sulfuric_metal_solution', 'gtceu:sulfuric_copper_solution')
 	event.add('tfg:sulfuric_metal_solution', 'gtceu:sulfuric_nickel_solution')
+
+	// GT fluid input recipe modification bug workaround
+	// GT adds these tags by itself already but not in time for our recipe modification to apply properly.
+	event.add('forge:polyethylene',      'gtceu:polyethylene')
+	event.add('forge:sodium_persulfate', 'gtceu:sodium_persulfate')
+	event.add('forge:iron_iii_chloride', 'gtceu:iron_iii_chloride')
+	event.add('forge:tin',               'gtceu:tin')
+	event.add('forge:soldering_alloy',   'gtceu:soldering_alloy')
 }
 //#endregion
 


### PR DESCRIPTION
## What is the new behavior?
Should fix the fluid replacement issues

Closes #3275 because it's not necessary anymore

## Implementation Details
Add the #forge tags that GT uses internally early on in the process. That way the recipe modification works because the forge tags are not empty.

## Outcome
\o/

## Additional Information
Hopefully GT will stop doing the weird tag thing, then we don't need this anymore. It won't break anything if they change it, luckily.