### PR TITLE
Fix 3 Deafission recipe loading errors (missing duration)

### DIFF
--- a/kubejs/server_scripts/tfg/powergen/nuclear/recipes.nuclear.js
+++ b/kubejs/server_scripts/tfg/powergen/nuclear/recipes.nuclear.js
@@ -882,6 +882,7 @@ function registerTFGNuclearRecipes(event) {
         .outputFluids(Fluid.of('tfg:boron_enriched_coolant', 3600))
         .blastFurnaceTemp(2000)
         .addData("hb_energy", 30)
+		.duration(20*5)
 /*
     event.recipes.deafission.hb_export('tfg:boron_coolant_to_dense_steam')
         .inputFluids(Fluid.of('gtceu:distilled_water', 7200))
@@ -895,6 +896,7 @@ function registerTFGNuclearRecipes(event) {
         .outputFluids(Fluid.of('gtceu:dense_steam', 115200))
         .blastFurnaceTemp(1000)
         .addData("hb_energy", 40)
+		.duration(20*5)
 		//.circuit(2)
 
     event.recipes.deafission.hb_import('tfg:dense_steam')
@@ -902,6 +904,7 @@ function registerTFGNuclearRecipes(event) {
         .outputFluids(Fluid.of('minecraft:water', 20))
         .blastFurnaceTemp(1000)
         .addData("hb_energy", 20)
+		.duration(20*5)
 	
 	//#endregion
 


### PR DESCRIPTION
## What is the new behavior?
This PR fixes 3 Deafission recipes that failed to load because the required `duration` field was missing.

## Implementation Details
- Added the missing `duration` value to 3 Deafission recipes.

## Outcome
- The `No key duration` recipe load errors are removed.
- All 3 affected Deafission recipes now load correctly.

## Potential Compatibility Issues
Low risk. Changes are limited to recipe timing fields (`duration`) for 3 Deafission recipes.