### PR TITLE
Factory gauge crafting uses diode tag

### DIFF
--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -1886,14 +1886,14 @@ const registerCreateRecipes = (event) => {
 	], {
 		A: 'create:precision_mechanism',
 		C: '#forge:screws/aluminium',
-		D: 'gtceu:diode',
+		D: '#gtceu:diodes',
 		E: '#gtceu:circuits/lv',
 		F: '#forge:plates/rose_quartz',
 		G: '#forge:tools/wrenches'
 	}).id('tfg:create/shaped/factory_gauge')
 
 	event.recipes.gtceu.assembler('create:factory_gauge')
-		.itemInputs('create:precision_mechanism', '2x #forge:screws/aluminium', 'gtceu:diode', '3x #forge:plates/rose_quartz', '#gtceu:circuits/lv')
+		.itemInputs('create:precision_mechanism', '2x #forge:screws/aluminium', '#gtceu:diodes', '3x #forge:plates/rose_quartz', '#gtceu:circuits/lv')
 		.itemOutputs('create:factory_gauge')
 		.duration(150)
 		.EUt(16)

--- a/kubejs/server_scripts/create_factory_logistics/recipes.js
+++ b/kubejs/server_scripts/create_factory_logistics/recipes.js
@@ -50,14 +50,14 @@ function registerCreateFactoryLogisticsRecipes(event) {
 	], {
 		A: 'create_factory_logistics:fluid_mechanism',
 		C: '#forge:screws/aluminium',
-		D: 'gtceu:diode',
+		D: '#gtceu:diodes',
 		E: '#gtceu:circuits/lv',
 		F: '#forge:plates/rose_quartz',
 		G: '#forge:tools/wrenches'
 	}).id('create_factory_logistics:shaped/factory_fluid_gauge')
 
 	event.recipes.gtceu.assembler('create_factory_logistics:factory_fluid_gauge')
-		.itemInputs('create_factory_logistics:fluid_mechanism', '2x #forge:screws/aluminium', 'gtceu:diode', '3x #forge:plates/rose_quartz', '#gtceu:circuits/lv')
+		.itemInputs('create_factory_logistics:fluid_mechanism', '2x #forge:screws/aluminium', '#gtceu:diodes', '3x #forge:plates/rose_quartz', '#gtceu:circuits/lv')
 		.itemOutputs('create_factory_logistics:factory_fluid_gauge')
 		.duration(150)
 		.EUt(16)


### PR DESCRIPTION
## What is the new behavior?
Change factory gauge crafting recipe to use diode tag, so that diodes and SMD diodes can be used

## Outcome
Makes crafting gauges possible with the easier diode recipe at HV