### PR TITLE
TFC Jams use Sweeteners

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -171,6 +171,11 @@ const registerTFCRecipes = (event) => {
 
 	event.replaceInput({ mod: 'tfc' }, 'minecraft:sugar', '#tfg:sugars')
 
+	event.replaceInput(
+		{ type: 'tfc:pot_jam' },
+		'#tfg:sugars',
+		'#tfc:sweetener'
+	)
 
 	// jute net -> burlap net
 	event.replaceInput({ id: 'tfc:crafting/jute_net' }, 'tfc:jute_fiber', '#tfg:burlap_fiber')
@@ -295,10 +300,4 @@ const registerTFCRecipes = (event) => {
 			A: `tfc:wood/sapling/${type}`
 		}).id(`tfg:shaped/tfc/${type}_krummholz`);
 	});
-
-	event.replaceInput(
-		{ type: 'tfc:pot_jam' },
-		'#tfg:sugars',
-		'#tfc:sweetener'
-	)
 }


### PR DESCRIPTION
### What is the new behavior?
TFC Jams take #tfc:sweetener instead of #tfg:sugar in pot recipes.

### Implementation Details
- Modified kubejs/server_scripts/tfc/recipes.js

### Additional Information
- #3319 

### Discord
@sakura.kitsurugi