### PR TITLE
Fix jam sandwich food processor recipes

### DIFF
--- a/kubejs/server_scripts/tfg/food/recipes.food.js
+++ b/kubejs/server_scripts/tfg/food/recipes.food.js
@@ -199,11 +199,11 @@ function registerTFGFoodRecipes(event) {
 				])
 			})
 
-			//Note: Jam needs to be first in the recipe code or else it will consider it as the usable_in_jam_sandwhich ingredients.
-			//1 Jam
+			//Note: preserves needs to be first in the recipe code or else it will consider it as the usable_in_jam_sandwich ingredients.
+			// 1 jam + 2 cheese
 			global.processorRecipe(event, `${grain}_${type[0]}_jam_sandwich_1`, 100, 16, {
 				circuit: 4,
-				itemInputs: [`2x ${type[1]}`, '#tfc:foods/preserves', '2x #tfc:foods/usable_in_jam_sandwich_2'],
+				itemInputs: [`2x ${type[1]}`, '#tfc:foods/preserves', '2x #tfc:foods/usable_in_jam_sandwich'],
 				itemOutputs: [`2x tfc:food/${grain}_bread_jam_sandwich`, 'tfc:empty_jar'],
 				itemOutputProvider: TFC.isp.of(`2x tfc:food/${grain}_bread_jam_sandwich`).meal(
 					(food => food.hunger(4).water(0.5).saturation(1).decayModifier(4.5)), [
@@ -212,10 +212,10 @@ function registerTFGFoodRecipes(event) {
 				])
 			})
 
-			//2 Jam
+			// 2 jam + 1 cheese. Uses preserves_2 alias so GT's RecipeDB gives this a distinct tree key from recipe 1.
 			global.processorRecipe(event, `${grain}_${type[0]}_jam_sandwich_2`, 100, 16, {
 				circuit: 4,
-				itemInputs: [`2x ${type[1]}`, '2x #tfc:foods/preserves', '1x #tfc:foods/usable_in_jam_sandwich_2'],
+				itemInputs: [`2x ${type[1]}`, '2x #tfc:foods/preserves_2', '1x #tfc:foods/usable_in_jam_sandwich'],
 				itemOutputs: [`2x tfc:food/${grain}_bread_jam_sandwich`, '2x tfc:empty_jar'],
 				itemOutputProvider: TFC.isp.of(`2x tfc:food/${grain}_bread_jam_sandwich`).meal(
 					(food => food.hunger(4).water(0.5).saturation(1).decayModifier(4.5)), [
@@ -224,7 +224,7 @@ function registerTFGFoodRecipes(event) {
 				])
 			})
 
-			//3 Jam
+			// 3 jam
 			global.processorRecipe(event, `${grain}_${type[0]}_jam_sandwich_3`, 100, 16, {
 				circuit: 4,
 				itemInputs: [`2x ${type[1]}`, '3x #tfc:foods/preserves'],

--- a/kubejs/server_scripts/tfg/food/tags.food.js
+++ b/kubejs/server_scripts/tfg/food/tags.food.js
@@ -45,15 +45,8 @@ function registerTFGFoodItemTags(event) {
 
 	global.WARMING_FOODS.forEach(food => { event.add('tfg:warming_foods', food) })
 
-	//jam sandwhich stuff
-	const usable_in_jam_sandwich = Ingredient.of('#tfc:foods/usable_in_jam_sandwich').itemIds.toArray().map(String);
-	const preserves = Ingredient.of('#tfc:foods/preserves').itemIds.toArray().map(String);
-
-	const usable_in_jam_sandwich_2 = usable_in_jam_sandwich.filter(item => !preserves.includes(item));
-
-	usable_in_jam_sandwich_2.forEach(item => {
-		event.add('tfc:foods/usable_in_jam_sandwich_2', item);
-	});
+	// Alias of tfc:foods/preserves, used to give the 2-jam sandwich recipe a distinct tree key in GT's RecipeDB.
+	event.add('tfc:foods/preserves_2', '#tfc:foods/preserves')
 
 	event.add('tfg:raw_dinosaur_meat', 'tfg:food/raw_sniffer_beef')
 	event.add('tfg:raw_dinosaur_meat', 'tfg:food/raw_wraptor')
@@ -332,7 +325,6 @@ function registerTFGFoodItemTags(event) {
 	event.add('tfc:foods/dairy', 'ad_astra:cheese')
 	event.add('tfc:foods/usable_in_sandwich', 'ad_astra:cheese')
 	event.add('tfc:foods/usable_in_jam_sandwich', 'ad_astra:cheese')
-	event.add('tfc:foods/usable_in_jam_sandwich_2', 'ad_astra:cheese')
 	event.add('firmalife:foods/cheeses', 'ad_astra:cheese')
 
 	// Auto-eat blacklist for backpack feeding upgrade and quarktech helmet

--- a/kubejs/startup_scripts/tfg/items.food.js
+++ b/kubejs/startup_scripts/tfg/items.food.js
@@ -487,7 +487,6 @@ function registerTFGFoodItems(event) {
 			})
 		)
 		.tag('tfc:foods/usable_in_jam_sandwich')
-		.tag('tfc:foods/usable_in_jam_sandwich_2')
 		.tag('tfc:foods/usable_in_sandwich')
 		.tag('tfg:foods/usable_in_meal_bag')
 		.tag('tfc:foods/dairy')


### PR DESCRIPTION
## What is the new behavior?
Fixes #3388

## Bug details
The useable_in_jam_sandwiches_2 tag got built from the other tags too early, before all items were registered. So it ended up not having the required dairy.

## Latent bug details
GT doesn't support having recipes with the same input items but different amounts, so you can't have [1 jam 2 cheese] and [2 jam 1 cheese] as distinct recipes.

## Fix details
Remove useable_in_jam_sandwiches_2
Make a copy of the preserves tag called tfc:foods/preserves_2
Use preserves_2 for the [2 jam 1 cheese] sandwich to give it distinct inputs for GT's RecipeDB

## Discarded fix that would work also work
Don't build useable_in_jam_sandwiches_2 from the other tags by iterating, instead define it lazily out of other tags (#cheese, #preserves, etc) that will have the correct items in the future. You'd still need to make the recipes distinct by using _2 only for one of them but not the other.