### PR TITLE
Vitrified ender pearls use ender pearl tag

### DIFF
--- a/kubejs/server_scripts/tfg/machines/recipes.ender_pearls.js
+++ b/kubejs/server_scripts/tfg/machines/recipes.ender_pearls.js
@@ -20,7 +20,7 @@ function registerTFGEnderPearlRecipes(event) {
 		.EUt(GTValues.VA[GTValues.HV])
 
 	event.recipes.gtceu.pyrolyse_oven('vitrified_ender_dust')
-		.itemInputs('minecraft:ender_pearl', '2x tfc:powder/kaolinite', '4x #forge:insulation_t1')
+		.itemInputs('#forge:ender_pearls', '2x tfc:powder/kaolinite', '4x #forge:insulation_t1')
 		.inputFluids(Fluid.of('gtceu:nitrogen', 100))
 		.itemOutputs('tfg:vitrified_pearl')
 		.chancedOutput('gtceu:ash_dust', 2500, 0)


### PR DESCRIPTION
## What is the new behavior?
Vitrified ender pearls use ender pearl tag

## Outcome
So you can use the ender pearls dropped by beneath endermen