### PR TITLE
Allow tfc bricks to stonecut into other brick variants

### DIFF
--- a/kubejs/server_scripts/tfg/natural_blocks/recipes.rocks.js
+++ b/kubejs/server_scripts/tfg/natural_blocks/recipes.rocks.js
@@ -409,13 +409,9 @@ function registerTFGRockRecipes(event) {
 		if (rock.stonecutting != null) {
 			rock.stonecutting.forEach(stonecuttingEntry => {
 				changeForms(rockId, rock, stonecuttingEntry);
-				if (rock.isTFC) {
-					// Add a recipe for this stonecutter entry that uses the regular brick
-					let tfcBrick = `tfc:rock/bricks/${rockId}`;
-					let id = linuxUnfucker(`${tfcBrick}_to_${stonecuttingEntry.block}`);
-					event.stonecutting(`${stonecuttingEntry.block}`, tfcBrick)
-						.id(`tfg:stonecutting/${id}`);
-				}
+				let id = linuxUnfucker(`${rock.bricks.block}_to_${stonecuttingEntry.block}`);
+				event.stonecutting(`${stonecuttingEntry.block}`, rock.bricks.block)
+					.id(`tfg:stonecutting/${id}`);
 			})
 		}
 


### PR DESCRIPTION
## What is the new behavior?
Re-adds recipes for regular bricks -> all of its stonecutter variants (e.g marble bricks -> square marble bricks, andesite bricks -> create brick variants, etc)

## Implementation Details
For each TFC rock, just add a recipe to use the brick for each given stonecutter variant. Maybe not the cleanest solution, but it works.