### PR TITLE
Disable Creative Tabs in EMI++ by Default

### DIFF
--- a/config/emixx/emixx-client.toml
+++ b/config/emixx/emixx-client.toml
@@ -1,0 +1,10 @@
+
+[creativeModeTabs]
+	enableCreativeModeTabs = false
+	syncSelectedCreativeModeTab = true
+	enableBerryTheme = false
+	disabledCreativeModeTabs = ["minecraft:op_blocks"]
+
+[stackGroups]
+	enableStackGroups = true
+


### PR DESCRIPTION

### What is the new behavior?
Adds a config that by default disables creative tabs in EMI++

### Implementation Details
Added config/emixx/emixx-client.toml

### Additional Information
- Creative tabs ignore tags that hide items from EMI
- #3475

### Discord
@sakura.kitsurugi

