### PR TITLE
SNR additional recipes for pre-LV

### DIFF
--- a/kubejs/server_scripts/railways/recipes.js
+++ b/kubejs/server_scripts/railways/recipes.js
@@ -60,10 +60,19 @@ const registerRailWaysRecipes = (event) => {
 		'screwlink_coupler'
 	]
 
+	event.shapeless('railways:link_and_pin', [
+		'minecraft:tripwire_hook',
+		'#forge:plates/steel',
+		'#forge:screws/steel',
+		'#forge:tools/hammers'
+	]).id('railways:shapeless/link_and_pin')
+
 	event.stonecutting(`railways:wooden_headstock`, '#minecraft:wooden_slabs');
 	event.stonecutting(`4x railways:copycat_headstock`, '#forge:ingots/zinc');
 
 	SNR_BASE_COUPLERS.forEach((coupler, i) => {
+		event.stonecutting(`#railways:deco_couplers`, `railways:${coupler}`);
+		
 		event.recipes.gtceu.assembler(`tfg:railways/${coupler}`)
 			.itemInputs(`minecraft:tripwire_hook`, `#forge:plates/steel`, '#forge:screws/steel')
 			.circuit(i + 1)
@@ -72,12 +81,22 @@ const registerRailWaysRecipes = (event) => {
 			.EUt(28)
 			.addMaterialInfo(true)
 
+		event.shapeless(`railways:wooden_headstock_${coupler}`, [
+			`railways:${coupler}`,
+			`railways:wooden_headstock`
+		]).id(`railways:shapeless/wooden_headstock_${coupler}`)
+
 		event.recipes.gtceu.assembler(`tfg:railways/wooden_headstock_${coupler}`)
 			.itemInputs(`railways:${coupler}`, `railways:wooden_headstock`)
 			.itemOutputs(`railways:wooden_headstock_${coupler}`)
 			.duration(200)
 			.EUt(28)
 			.addMaterialInfo(true)
+
+		event.shapeless(`railways:copycat_headstock_${coupler}`, [
+			`railways:${coupler}`,
+			`railways:copycat_headstock`
+		]).id(`railways:shapeless/copycat_headstock_${coupler}`)
 
 		event.recipes.gtceu.assembler(`tfg:railways/copycat_headstock_${coupler}`)
 			.itemInputs(`railways:${coupler}`, `railways:copycat_headstock`)
@@ -87,6 +106,12 @@ const registerRailWaysRecipes = (event) => {
 			.addMaterialInfo(true)
 	})
 
+	event.shapeless(`railways:small_buffer`, [
+		`#railways:deco_couplers`,
+		`#forge:ingots/steel`,
+		`#forge:tools/hammers`
+	]).id(`railways:shapeless/small_buffer`)
+
 	event.recipes.gtceu.assembler(`tfg:railways/small_buffer`)
 		.itemInputs(`#railways:deco_couplers`, `#forge:ingots/steel`)
 		.circuit(1)
@@ -94,6 +119,12 @@ const registerRailWaysRecipes = (event) => {
 		.duration(200)
 		.EUt(28)
 		.addMaterialInfo(true)
+
+	event.shapeless(`railways:big_buffer`, [
+		`railways:small_buffer`,
+		`#forge:ingots/steel`,
+		`#forge:tools/hammers`
+	]).id(`railways:shapeless/big_buffer`)
 
 	event.recipes.gtceu.assembler(`tfg:railways/big_buffer`)
 		.itemInputs(`railways:small_buffer`, `#forge:ingots/steel`)
@@ -103,6 +134,16 @@ const registerRailWaysRecipes = (event) => {
 		.EUt(28)
 		.addMaterialInfo(true)
 
+	event.shaped('railways:buffer', [
+		'BAB',
+		'AAA',
+		'ACA'
+		], {
+		A: '#forge:rods/long/steel',
+		B: 'railways:small_buffer',
+		C: '#forge:tools/hammers'
+	}).id('railways:shaped/buffer')
+
 	event.recipes.gtceu.assembler(`tfg:railways/buffer`)
 		.itemInputs(`6x #forge:rods/long/steel`, `2x railways:small_buffer`)
 		.circuit(1)
@@ -111,12 +152,22 @@ const registerRailWaysRecipes = (event) => {
 		.EUt(28)
 		.addMaterialInfo(true)
 
+	event.shapeless(`railways:wooden_headstock_buffer`, [
+		`railways:small_buffer`,
+		`railways:wooden_headstock`
+	]).id(`railways:shapeless/wooden_headstock_buffer`)
+
 	event.recipes.gtceu.assembler(`tfg:railways/wooden_headstock_buffer`)
 		.itemInputs(`railways:small_buffer`, `railways:wooden_headstock`)
 		.itemOutputs(`railways:wooden_headstock_buffer`)
 		.duration(200)
 		.EUt(28)
 		.addMaterialInfo(true)
+
+	event.shapeless(`railways:copycat_headstock_buffer`, [
+		`railways:small_buffer`,
+		`railways:copycat_headstock`
+	]).id(`railways:shapeless/copycat_headstock_buffer`)
 
 	event.recipes.gtceu.assembler(`tfg:railways/copycat_headstock_buffer`)
 		.itemInputs(`railways:small_buffer`, `railways:copycat_headstock`)
@@ -411,7 +462,11 @@ const registerRailWaysRecipes = (event) => {
 			.EUt(28)
 				
 		SNR_SMOKESTACK_TYPES.forEach(type => {
+	
 			if(mat.craft_mat != 'brass') {
+				event.recipes.createItemApplication([`railways:smokestack_${type}_brass_cap${mat.capped_mat}`], [`railways:smokestack_${type}${mat.base_mat}`, '#forge:bolts/brass'])
+					.id(`tfg:railways/item_application/smokestack_${type}_brass_cap${mat.capped_mat}`)
+
 				event.recipes.gtceu.chemical_bath(`railways:smokestack_${type}_brass_cap${mat.capped_mat}`)
 					.itemInputs(`railways:smokestack_${type}${mat.base_mat}`)
 					.inputFluids('gtceu:brass 18')
@@ -421,6 +476,9 @@ const registerRailWaysRecipes = (event) => {
 					.category(GTRecipeCategories.CHEM_DYES)
 			}
 			if(mat.craft_mat != 'copper') {
+				event.recipes.createItemApplication([`railways:smokestack_${type}_copper_cap${mat.capped_mat}`], [`railways:smokestack_${type}${mat.base_mat}`, '#forge:bolts/copper'])
+					.id(`tfg:railways/item_application/smokestack_${type}_copper_cap${mat.capped_mat}`)
+
 				event.recipes.gtceu.chemical_bath(`railways:smokestack_${type}_copper_cap${mat.capped_mat}`)
 					.itemInputs(`railways:smokestack_${type}${mat.base_mat}`)
 					.inputFluids('gtceu:copper 18')
@@ -429,6 +487,9 @@ const registerRailWaysRecipes = (event) => {
 					.EUt(24)
 					.category(GTRecipeCategories.CHEM_DYES)
 			}
+			event.recipes.createItemApplication([`railways:smokestack_${type}_iron_cap${mat.capped_mat}`], [`railways:smokestack_${type}${mat.base_mat}`, '#forge:bolts/wrought_iron'])
+				.id(`tfg:railways/item_application/smokestack_${type}_iron_cap${mat.capped_mat}`)
+
 			event.recipes.gtceu.chemical_bath(`railways:smokestack_${type}_iron_cap${mat.capped_mat}`)
 				.itemInputs(`railways:smokestack_${type}${mat.base_mat}`)
 				.inputFluids('gtceu:wrought_iron 18')

--- a/kubejs/server_scripts/railways/recipes.locometal.js
+++ b/kubejs/server_scripts/railways/recipes.locometal.js
@@ -1,6 +1,4 @@
 "use strict";
-// NEW ITEMS:
-// Wrapped Smokebox wrapped_locometal_smokebox
 
 const locometalDyeGroups = {
 	riveted_locometal: '#railways:palettes/dye_groups/riveted',
@@ -67,6 +65,19 @@ const LOCOMETAL_COLORS = [
 
 const registerRailwaysLocometalRecipes = (event) => {
 	// Base & Wrapped Locometal Boiler
+	event.shapeless('railways:locometal_boiler', [
+		'#railways:palettes/cycle_groups/netherite/base',
+		'create:fluid_tank',
+		'#forge:tools/screwdrivers'
+	]).id('tfg:shapeless/locometal_boiler')
+
+	event.recipes.createItemApplication(['railways:brass_wrapped_locometal_boiler'], ['railways:locometal_boiler', '#forge:plates/brass'])
+		.id('tfg:railways/item_application/brass_wrapped_locometal_boiler')
+	event.recipes.createItemApplication(['railways:copper_wrapped_locometal_boiler'], ['railways:locometal_boiler', '#forge:plates/copper'])
+		.id('tfg:railways/item_application/copper_wrapped_locometal_boiler')
+	event.recipes.createItemApplication(['railways:iron_wrapped_locometal_boiler'], ['railways:locometal_boiler', '#forge:plates/wrought_iron'])
+		.id('tfg:railways/item_application/iron_wrapped_locometal_boiler')
+
 	event.recipes.gtceu.assembler(`tfg:railways/locometal_boiler`)
 		.itemInputs('#railways:palettes/cycle_groups/netherite/base', `create:fluid_tank`)
 		.circuit(1)
@@ -93,6 +104,13 @@ const registerRailwaysLocometalRecipes = (event) => {
 		.EUt(28)
 	
 	// Wrapped Locometal Recipes
+	event.recipes.createItemApplication(['railways:brass_wrapped_locometal'], ['railways:slashed_locometal', '#forge:bolts/brass'])
+		.id('tfg:railways/item_application/brass_wrapped_locometal')
+	event.recipes.createItemApplication(['railways:copper_wrapped_locometal'], ['railways:slashed_locometal', '#forge:bolts/copper'])
+		.id('tfg:railways/item_application/copper_wrapped_locometal')
+	event.recipes.createItemApplication(['railways:iron_wrapped_locometal'], ['railways:slashed_locometal', '#forge:bolts/wrought_iron'])
+		.id('tfg:railways/item_application/iron_wrapped_locometal')
+
 	event.recipes.gtceu.chemical_bath(`railways:brass_wrapped_locometal`)
 		.itemInputs(`railways:slashed_locometal`)
 		.inputFluids('gtceu:brass 18')
@@ -116,6 +134,13 @@ const registerRailwaysLocometalRecipes = (event) => {
 		.category(GTRecipeCategories.CHEM_DYES);
 
 	// Wrapped Smokebox Recipes
+	event.recipes.createItemApplication(['railways:wrapped_locometal_smokebox'], ['railways:locometal_smokebox', '#forge:bolts/brass'])
+		.id('tfg:railways/item_application/wrapped_locometal_smokebox')
+	event.recipes.createItemApplication(['railways:copper_wrapped_locometal_smokebox'], ['railways:locometal_smokebox', '#forge:bolts/copper'])
+		.id('tfg:railways/item_application/copper_wrapped_locometal_smokebox')
+	event.recipes.createItemApplication(['railways:iron_wrapped_locometal_smokebox'], ['railways:locometal_smokebox', '#forge:bolts/wrought_iron'])
+		.id('tfg:railways/item_application/iron_wrapped_locometal_smokebox')
+
 	event.recipes.gtceu.chemical_bath(`railways:brass_wrapped_locometal_smokebox`)
 		.itemInputs(`railways:locometal_smokebox`)
 		.inputFluids('gtceu:brass 18')
@@ -180,10 +205,12 @@ const registerRailwaysLocometalRecipes = (event) => {
 
 	// Base RNR Flywheel Recipes
 	event.shapeless('railways:locometal_flywheel', [
-		'create:flywheel'
+		'create:flywheel',
+		'#forge:tools/screwdrivers'
 	]).id('tfg:shapeless/create_flywheel_to_snr_flywheel')
 	event.shapeless('create:flywheel', [
-		'railways:locometal_flywheel'
+		'railways:locometal_flywheel',
+		'#forge:tools/screwdrivers'
 	]).id('tfg:shapeless/snr_flywheel_to_create_flywheel')
 
 	// Locometal Glass Block Recipes
@@ -294,6 +321,13 @@ const registerRailwaysLocometalRecipes = (event) => {
 				}
 				
 			// Wrapped Locometal Colored Recipes
+			event.recipes.createItemApplication([`railways:${color}_brass_wrapped_locometal`], [`railways:${color}_slashed_locometal`, '#forge:bolts/brass'])
+				.id(`tfg:railways/item_application/${color}_brass_wrapped_locometal`)
+			event.recipes.createItemApplication([`railways:${color}_copper_wrapped_locometal`], [`railways:${color}_slashed_locometal`, '#forge:bolts/copper'])
+				.id(`tfg:railways/item_application/${color}_copper_wrapped_locometal`)
+			event.recipes.createItemApplication([`railways:${color}_iron_wrapped_locometal`], [`railways:${color}_slashed_locometal`, '#forge:bolts/wrought_iron'])
+				.id(`tfg:railways/item_application/${color}_iron_wrapped_locometal`)
+
 			event.recipes.gtceu.chemical_bath(`tfg:brass_locometal_bathing/${color}`)
 				.itemInputs('#railways:palettes/dye_groups/brass_wrapped_slashed')
 				.inputFluids(Fluid.of(`${x.dye}`, 18))
@@ -320,6 +354,26 @@ const registerRailwaysLocometalRecipes = (event) => {
 				.category(GTRecipeCategories.CHEM_DYES)
 
 			// Base & Wrapped Boiler Colored Recipes
+			event.shapeless(`railways:${color}_locometal_boiler`, [
+				`#railways:palettes/cycle_groups/${color}/base`,
+				`create:fluid_tank`,
+				`#forge:tools/screwdrivers`
+			]).id(`tfg:shapeless/${color}_locometal_boiler`)
+
+			event.recipes.createItemApplication([`railways:${color}_brass_wrapped_locometal_boiler`], [`railways:${color}_locometal_boiler`, '#forge:plates/brass'])
+				.id(`tfg:railways/item_application/${color}_brass_wrapped_locometal_boiler`)
+			event.recipes.createItemApplication([`railways:${color}_copper_wrapped_locometal_boiler`], [`railways:${color}_locometal_boiler`, '#forge:plates/copper'])
+				.id(`tfg:railways/item_application/${color}_copper_wrapped_locometal_boiler`)
+			event.recipes.createItemApplication([`railways:${color}_iron_wrapped_locometal_boiler`], [`railways:${color}_locometal_boiler`, '#forge:plates/wrought_iron'])
+				.id(`tfg:railways/item_application/${color}_iron_wrapped_locometal_boiler`)
+
+			event.recipes.gtceu.assembler(`tfg:railways/${color}_locometal_boiler`)
+				.itemInputs(`#railways:palettes/cycle_groups/${color}/base`, `create:fluid_tank`)
+				.circuit(1)
+				.itemOutputs(`railways:${color}_locometal_boiler`)
+				.duration(200)
+				.EUt(28)
+
 			event.recipes.gtceu.chemical_bath(`tfg:railways/locometal_boiler/color/${color}`)
 				.itemInputs('#railways:palettes/dye_groups/boiler')
 				.inputFluids(Fluid.of(`${x.dye}`, 72))
@@ -354,6 +408,13 @@ const registerRailwaysLocometalRecipes = (event) => {
 				.category(GTRecipeCategories.CHEM_DYES)
 
 			// Wrapped Smokebox Colored Recipes
+			event.recipes.createItemApplication([`railways:${color}_wrapped_locometal_smokebox`], [`railways:${color}_locometal_smokebox`, '#forge:bolts/brass'])
+				.id(`tfg:railways/item_application/${color}_wrapped_locometal_smokebox`)
+			event.recipes.createItemApplication([`railways:${color}_copper_wrapped_locometal_smokebox`], [`railways:${color}_locometal_smokebox`, '#forge:bolts/copper'])
+				.id(`tfg:railways/item_application/${color}_copper_wrapped_locometal_smokebox`)
+			event.recipes.createItemApplication([`railways:${color}_iron_wrapped_locometal_smokebox`], [`railways:${color}_locometal_smokebox`, '#forge:bolts/wrought_iron'])
+				.id(`tfg:railways/item_application/${color}_iron_wrapped_locometal_smokebox`)
+
 			event.recipes.gtceu.chemical_bath(`tfg:brass_locometal_smokebox_bathing/${color}`)
 				.itemInputs('#railways:palettes/dye_groups/brass_wrapped_smokebox')
 				.inputFluids(Fluid.of(`${x.dye}`, 18))


### PR DESCRIPTION

### What is the new behavior?
Adds shaped and shapeless recipes for creating couplers, buffers and base boilers pre-LV.

Also adds a way to craft wrapped metal blocks by interacting with it using an appropriate item.

### Implementation Details
Modified Create: Steam 'n' Rails kubeJS in recipes.locometal.js and recipes.js

### Additional Information
- #3474
- Forgot to sync my dev so rocket fuel buff will have to be separate pull request.