### PR TITLE
Tamped Block Recipes for new Soil/Mud Blocks

### DIFF
--- a/kubejs/server_scripts/rnr/recipes.js
+++ b/kubejs/server_scripts/rnr/recipes.js
@@ -86,4 +86,73 @@ const registerRnrRecipes = (event) => {
 		.circuit(7)
 		.duration(200)
 		.EUt(GTValues.VA[GTValues.ULV])
+
+	// Tamped blocks for new world gen soils
+	const DIRT_VARIATIONS = [
+		"dirt",
+		"grass",
+		"rooted_dirt",
+		"clay",
+		"clay_grass",
+		"coarse_dirt",
+		"duff"
+	]
+
+	const MUD_VARIATIONS = [
+		"mud",
+		"muddy_roots"
+	]
+
+	global.TFG_MUD_TYPES.forEach(soil => {
+		DIRT_VARIATIONS.forEach(type => {
+			event.custom({
+				type: `rnr:mattock`,
+				ingredient: `tfg:${type}/${soil}`,
+				result: `tfg:tamped/dirt/${soil}`,
+				mode: `smooth`
+			})
+		})
+
+		MUD_VARIATIONS.forEach(type => {
+			event.custom({
+				type: `rnr:mattock`,
+				ingredient: `tfg:${type}/${soil}`,
+				result: `tfg:tamped/mud/${soil}`,
+				mode: `smooth`
+			})
+		})
+
+		event.custom({
+			type: `rnr:block_mod`,
+			input_item: {
+				item: `rnr:crushed_base_course`
+			},
+			input_block: `tfg:tamped/mud/${soil}`,
+			output_block: `tfg:tamped/soil/${soil}`
+		})
+
+		event.custom({
+			type: `rnr:block_mod`,
+			input_item: {
+				item: `rnr:crushed_base_course`
+			},
+			input_block: `tfg:tamped/dirt/${soil}`,
+			output_block: `rnr:base_course`
+		})
+	})
+
+	global.TFC_MUD_TYPES.forEach(soil => {
+		event.custom({
+			type: `rnr:mattock`,
+			ingredient: `tfg:coarse_dirt/${soil}`,
+			result: `rnr:tamped_${soil}`,
+			mode: `smooth`
+		})
+		event.custom({
+			type: `rnr:mattock`,
+			ingredient: `tfg:duff_${soil}`,
+			result: `rnr:tamped_${soil}`,
+			mode: `smooth`
+		})
+	})
 };

--- a/kubejs/server_scripts/tfg/natural_blocks/recipes.collapse.js
+++ b/kubejs/server_scripts/tfg/natural_blocks/recipes.collapse.js
@@ -110,6 +110,8 @@ function registerTFGCollapseRecipes(event) {
 		event.recipes.tfc.landslide(`tfg:clay/${dirt}`, `tfg:clay/${dirt}`)
 		event.recipes.tfc.landslide(`tfg:clay/${dirt}`, `tfg:clay_grass/${dirt}`)
 		event.recipes.tfc.landslide(`tfg:coarse_dirt/${dirt}`, `tfg:coarse_dirt/${dirt}`)
+		event.recipes.tfc.landslide(`tfg:tamped/dirt/${dirt}`, `tfg:tamped/dirt/${dirt}`)
+		event.recipes.tfc.landslide(`tfg:tamped/mud/${dirt}`, `tfg:tamped/mud/${dirt}`)
 	})
 
 	// Other


### PR DESCRIPTION

### What is the new behavior?
Added recipes to actually be able to create the new tamped blocks, includes landslide recipes.

### Implementation Details
- Modifed `recipe.js` in rnr folder to add the mattock recipes.
- Modified `recipes.collapse.js` in tfg folder to add landslide recipes.

### Additional Information
- Should only be pulled if next release will have https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/382 PR
- #3545