### PR TITLE
Tamped Recipe Fix

### DIFF
--- a/kubejs/server_scripts/rnr/recipes.js
+++ b/kubejs/server_scripts/rnr/recipes.js
@@ -128,7 +128,7 @@ const registerRnrRecipes = (event) => {
 				item: `rnr:crushed_base_course`
 			},
 			input_block: `tfg:tamped/mud/${soil}`,
-			output_block: `tfg:tamped/soil/${soil}`
+			output_block: `tfg:tamped/dirt/${soil}`
 		})
 
 		event.custom({
@@ -150,7 +150,7 @@ const registerRnrRecipes = (event) => {
 		})
 		event.custom({
 			type: `rnr:mattock`,
-			ingredient: `tfg:duff_${soil}`,
+			ingredient: `tfg:duff/${soil}`,
 			result: `rnr:tamped_${soil}`,
 			mode: `smooth`
 		})


### PR DESCRIPTION
### What is the new behavior?
While testing new world gen I found out that I used soil instead of dirt which broke recipes.