### PR TITLE
Wood Gear Assembler Recipes

### DIFF
--- a/kubejs/server_scripts/tfg/primitive/recipes.wood.js
+++ b/kubejs/server_scripts/tfg/primitive/recipes.wood.js
@@ -85,6 +85,7 @@ function registerTFGWoodRecipes(event) {
 		.itemOutputs('gtceu:small_wood_gear')
 		.duration(20)
 		.circuit(6)
+		.EUt(GTValues.VA[GTValues.LV])
 
 	event.recipes.gtceu.assembler("tfg:wood_gear")
 		.itemInputs('4x #minecraft:planks')
@@ -92,4 +93,5 @@ function registerTFGWoodRecipes(event) {
 		.itemOutputs('gtceu:wood_gear')
 		.duration(20)
 		.circuit(6)
+		.EUt(GTValues.VA[GTValues.LV])
 }


### PR DESCRIPTION
### What is the new behavior?
Adds small and normal wood cog recipes to the assembler.

### Implementation Details
- Modified `kubejs/server_scripts/tfg/primitive/recipes.wood.js`

### Additional Information
- Closes #3550 