### PR TITLE
Cooling/Warming Tooltip

### DIFF
--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -462,41 +462,6 @@ const registerTooltips = (event) => {
 		text.add(1, Text.translate('tfg.tooltip.obsolete.depreciated'))
 	})
 
-	// Drink effects
-	event.addAdvanced(['tfc_gourmet:kvass_bucket'], (item, advanced, text) => {
-		text.add(1, Text.translate('tfg.tooltip.cooling_foods'));
-	})
-	event.addAdvanced(['tfc_gourmet:lemonade_bucket'], (item, advanced, text) => {
-		text.add(1, Text.translate('tfg.tooltip.cooling_foods'));
-	})
-	event.addAdvanced(['tfc_gourmet:coffee_bucket'], (item, advanced, text) => {
-		text.add(1, Text.translate('tfg.tooltip.warming_foods'));
-	})
-	event.addAdvanced(['tfc_gourmet:cocoa_bucket'], (item, advanced, text) => {
-		text.add(1, Text.translate('tfg.tooltip.warming_foods'));
-	})
-	event.addAdvanced(['tfc_gourmet:tea_mint_bucket'], (item, advanced, text) => {
-		text.add(1, Text.translate('tfg.tooltip.warming_foods'));
-	})
-	event.addAdvanced(['tfc_gourmet:tea_chamomile_bucket'], (item, advanced, text) => {
-		text.add(1, Text.translate('tfg.tooltip.warming_foods'));
-	})
-	event.addAdvanced(['tfc_gourmet:tea_nettle_bucket'], (item, advanced, text) => {
-		text.add(1, Text.translate('tfg.tooltip.warming_foods'));
-	})
-	event.addAdvanced(['tfc_gourmet:tea_rosehip_bucket'], (item, advanced, text) => {
-		text.add(1, Text.translate('tfg.tooltip.warming_foods'));
-	})
-	event.addAdvanced(['tfc_gourmet:nalivka_bucket'], (item, advanced, text) => {
-		text.add(1, Text.translate('tfg.tooltip.cooling_foods'));
-	})
-	event.addAdvanced(['tfc:bucket/spring_water'], (item, advanced, text) => {
-		text.add(1, Text.translate('tfg.tooltip.warming_foods'));
-	})
-	event.addAdvanced(['gtceu:ice_bucket'], (item, advanced, text) => {
-		text.add(1, Text.translate('tfg.tooltip.cooling_foods'));
-	})
-
 	// Saw can silk harvest ice
 	//This kinda sucks, but it works. We're basically getting the default "silk_ice" harvesting tooltip, getting the index, then removing it.
 	//Then, we insert on that index our custom tooltip that tells the player it harvests ALL ice blocks

--- a/kubejs/server_scripts/tfg/tags.js
+++ b/kubejs/server_scripts/tfg/tags.js
@@ -253,6 +253,19 @@ const registerTFGFluidTags = (event) => {
 	event.add('tfg:oils', 'gtceu:oil_medium')
 	event.add('tfg:oils', 'gtceu:oil_heavy')
 
+	event.add('tfg:cooling_drinks', 'tfc_gourmet:kvass')
+	event.add('tfg:cooling_drinks', 'tfc_gourmet:lemonade')
+	event.add('tfg:cooling_drinks', 'tfc_gourmet:nalivka')
+	event.add('tfg:cooling_drinks', 'gtceu:ice')
+
+	event.add('tfg:warming_drinks', 'tfc_gourmet:coffee')
+	event.add('tfg:warming_drinks', 'tfc_gourmet:cocoa')
+	event.add('tfg:warming_drinks', 'tfc_gourmet:tea_mint')
+	event.add('tfg:warming_drinks', 'tfc_gourmet:tea_chamomile')
+	event.add('tfg:warming_drinks', 'tfc_gourmet:tea_nettle')
+	event.add('tfg:warming_drinks', 'tfc_gourmet:tea_rosehip')
+	event.add('tfg:warming_drinks', 'tfc:spring_water')
+
 	global.BREATHABLE_COMPRESSED_AIRS.forEach(x => {
 		event.add('tfg:breathable_compressed_air', x)
 	})


### PR DESCRIPTION
### What is the new behavior?
Removes hardcoded warming and cooling tooltips to use the new one from Core.

### Implementation Details
- Removed tooltip code from `kubejs/client_scripts/tooltips.js` for cooling and warming drinks.
- Added 2 new tag to cooling and warming drinks in `kubejs/server_scripts/tfg/tags.js`

### Additional Information
- https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/393