### PR TITLE
Add Create millstone recipes for TFC grain, to match quern

### DIFF
--- a/kubejs/server_scripts/tfg/food/recipes.food.js
+++ b/kubejs/server_scripts/tfg/food/recipes.food.js
@@ -145,6 +145,10 @@ function registerTFGFoodRecipes(event) {
 			itemOutputs: [`2x tfc:food/${grain}_flour`],
 			itemOutputProvider: TFC.isp.of(`2x tfc:food/${grain}_flour`).copyOldestFood()
 		})
+    event.recipes.create.milling(
+      `2x tfc:food/${grain}_flour`, 
+      `tfc:food/${grain}_grain`
+    )
 
 		event.recipes.tfc.advanced_shaped_crafting(
 			TFC.isp.of(`tfc:food/${grain}_flour`).copyFood(), [


### PR DESCRIPTION
## What is the new behavior?
Enables milling grains to flour using Create's millstone. Just to have a bit of quern parity (and more usefulness to the millstone during the early game, other than grinding flux/ore/other dusts).

## Implementation Details
Simply piggybacks a `recipes.create.milling` event in the `recipes.food.js` for-loop for each `TFC_GRAINS`. I put it next to the grain to flour comment in the same file so it's easy to reference later on.

## Outcome
Enables grain to flour recipes for Create's millstone.

### Discord details
lickorice
319285994253975553
