### PR TITLE
fix: Reordered Wrought Iron Grill recipe (GUI only)

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.metals.js
+++ b/kubejs/server_scripts/tfc/recipes.metals.js
@@ -237,6 +237,11 @@ function registerTFCMetalsRecipes(event) {
 		.resultFluid(Fluid.of('gtceu:iron', 288))
 		.id(`tfc:heating/grill`)
 
+	// Wrought Iron Grill
+	event.recipes.tfc.anvil('tfc:wrought_iron_grill', '#forge:double_plates/wrought_iron', ['punch_last', 'draw_any', 'punch_not_last'])
+		.tier(3)
+		.id(`tfc:anvil/wrought_iron_grill`)
+
 	// Ванильная дверь декрафт
 	event.recipes.tfc.heating('minecraft:iron_door', 1535)
 		.resultFluid(Fluid.of('gtceu:iron', 288))


### PR DESCRIPTION
Default Recipe:
https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/6022cfcb6ba056783fa85b0bbadab61c8f6e3dfd/src/main/resources/data/tfc/recipes/anvil/wrought_iron_grill.json#L1-L16


## What is the new behavior?
Current Wrought Iron Grill GUI:
<img width="1073" height="391" alt="image" src="https://github.com/user-attachments/assets/aceefe7a-24b0-4a78-9b85-540fb1b42968" />
For some reason, the icons aren't lined up right to left for this recipe only.
Original recipe:
https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/6022cfcb6ba056783fa85b0bbadab61c8f6e3dfd/src/main/resources/data/tfc/recipes/anvil/wrought_iron_grill.json#L1-L16

This will change the ordering to:
<img width="572" height="406" alt="image" src="https://github.com/user-attachments/assets/ec982148-8203-4f1c-a60b-74df4400b2f5" />

## Outcome
Overrode Wrought Iron Grill recipe (GUI only), recipe is unchanged

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
winjwinj