### PR TITLE
Honeyed apples from Create

### DIFF
--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -2483,13 +2483,4 @@ const registerCreateRecipes = (event) => {
 	event.smelting('#forge:ingots/tin', 'create:crushed_raw_tin')
 	event.smelting('#forge:ingots/lead', 'create:crushed_raw_lead')
 
-	// apple
-
-	event.shapeless('create:honeyed_apple', ['#tfc:foods/apples', 'firmalife:raw_honey'])
-	
-	event.recipes.gtceu.food_processor('create:honeyed_apple')
-	.itemInputs('#tfc:foods/apples', 'firmalife:raw_honey')
-	.itemOutputs('create:honeyed_apple')
-	.duration(60)
-	.EUt(16)
 }

--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -2486,4 +2486,10 @@ const registerCreateRecipes = (event) => {
 	// apple
 
 	event.shapeless('create:honeyed_apple', ['#tfc:foods/apples', 'firmalife:raw_honey'])
+	
+	event.recipes.gtceu.food_processor('create:honeyed_apple')
+	.itemInputs('#tfc:foods/apples', 'firmalife:raw_honey')
+	.itemOutputs('create:honeyed_apple')
+	.duration(60)
+	.EUt(16)
 }

--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -2482,4 +2482,8 @@ const registerCreateRecipes = (event) => {
 	event.smelting('#forge:ingots/silver', 'create:crushed_raw_silver')
 	event.smelting('#forge:ingots/tin', 'create:crushed_raw_tin')
 	event.smelting('#forge:ingots/lead', 'create:crushed_raw_lead')
+
+	// apple
+
+	event.shapeless('create:honeyed_apple', ['#tfc:foods/apples', 'firmalife:raw_honey'])
 }

--- a/kubejs/server_scripts/create/tags.js
+++ b/kubejs/server_scripts/create/tags.js
@@ -113,6 +113,7 @@ const registerCreateItemTags = (event) => {
 	event.add('forge:smooth_stone_slab', 'create:polished_cut_scorchia_slab')
 	event.add('forge:smooth_stone_slab', 'create:polished_cut_veridium_slab')
 
+	event.add('tfc:foods', 'create:honeyed_apple')
 	event.add('tfc:foods/fruits', 'create:honeyed_apple')
 }
 

--- a/kubejs/server_scripts/create/tags.js
+++ b/kubejs/server_scripts/create/tags.js
@@ -112,6 +112,8 @@ const registerCreateItemTags = (event) => {
 	event.add('forge:smooth_stone_slab', 'create:polished_cut_scoria_slab')
 	event.add('forge:smooth_stone_slab', 'create:polished_cut_scorchia_slab')
 	event.add('forge:smooth_stone_slab', 'create:polished_cut_veridium_slab')
+
+	event.add('tfc:foods/apple', 'create:honeyed_apple')
 }
 
 const registerCreateBlockTags = (event) => {

--- a/kubejs/server_scripts/create/tags.js
+++ b/kubejs/server_scripts/create/tags.js
@@ -113,7 +113,7 @@ const registerCreateItemTags = (event) => {
 	event.add('forge:smooth_stone_slab', 'create:polished_cut_scorchia_slab')
 	event.add('forge:smooth_stone_slab', 'create:polished_cut_veridium_slab')
 
-	event.add('tfc:foods/apple', 'create:honeyed_apple')
+	event.add('tfc:foods/fruits', 'create:honeyed_apple')
 }
 
 const registerCreateBlockTags = (event) => {

--- a/kubejs/server_scripts/tfg/data.js
+++ b/kubejs/server_scripts/tfg/data.js
@@ -356,6 +356,9 @@ function registerTFGItemSize(event) {
 	//Universal Compost Bags
 	event.itemSize("tfg:universal_compost_browns_bag", "tiny", "medium")
 	event.itemSize("tfg:universal_compost_greens_bag", "tiny", "medium")
+
+	//Honeyed Apples
+	event.itemSize("create:honeyed_apple", "small", "light")
 }
 
 //#endregion

--- a/kubejs/server_scripts/tfg/food/data.food.js
+++ b/kubejs/server_scripts/tfg/food/data.food.js
@@ -596,6 +596,15 @@ function registerTFGFoodData(event) {
 		food.saturation(1);
 	});
 
+	// Honeyed Apple
+	event.foodItem('create:honeyed_apple', (food) => {
+		food.hunger(3.5);
+		food.decayModifier(0.8);
+		food.water(5);
+		food.fruit(2);
+		food.saturation(1);
+	});
+
 	// Lavacado
 	event.foodItem('tfg:food/lavacado', (food) => {
 		food.hunger(3.5);

--- a/kubejs/server_scripts/tfg/food/recipes.food.js
+++ b/kubejs/server_scripts/tfg/food/recipes.food.js
@@ -1314,12 +1314,12 @@ function registerTFGFoodRecipes(event) {
 
 	event.recipes.tfc.advanced_shapeless_crafting(TFC.isp.of('create:honeyed_apple').copyFood(), ['#tfc:foods/apples', 'firmalife:raw_honey'])
 	
-	event.recipes.gtceu.food_processor('create:honeyed_apple')
-		.itemInputs('#tfc:foods/apples', 'firmalife:raw_honey')
-		.itemOutputs(TFC.isp.of('create:honeyed_apple').copyFood())
-		.circuit(5)
-		.duration(60)
-		.EUt(16)
+	global.processorRecipe(event, 'honeyed_apple', 5 * 20, GTValues.VA[GTValues.ULV], {
+		itemInputs: ['#tfc:foods/apples', 'firmalife:raw_honey'],
+		itemOutputs: ['create:honeyed_apple'],
+		circuit: 5,
+		itemOutputProvider: TFC.isp.of('create:honeyed_apple').copyFood()
+	})
 
 	//#region New foods
 

--- a/kubejs/server_scripts/tfg/food/recipes.food.js
+++ b/kubejs/server_scripts/tfg/food/recipes.food.js
@@ -1310,6 +1310,17 @@ function registerTFGFoodRecipes(event) {
 		itemOutputProvider: TFC.isp.of('minecraft:golden_apple').resetFood()
 	})
 
+	//Honeyed Apple
+
+	event.shapeless('create:honeyed_apple', ['#tfc:foods/apples', 'firmalife:raw_honey'])
+	
+	event.recipes.gtceu.food_processor('create:honeyed_apple')
+		.itemInputs('#tfc:foods/apples', 'firmalife:raw_honey')
+		.itemOutputs(TFC.isp.of('create:honeyed_apple').resetFood())
+		.circuit(5)
+		.duration(60)
+		.EUt(16)
+
 	//#region New foods
 
 	event.recipes.tfc.heating('tfg:food/raw_birt', 200)

--- a/kubejs/server_scripts/tfg/food/recipes.food.js
+++ b/kubejs/server_scripts/tfg/food/recipes.food.js
@@ -1312,11 +1312,11 @@ function registerTFGFoodRecipes(event) {
 
 	//Honeyed Apple
 
-	event.shapeless('create:honeyed_apple', ['#tfc:foods/apples', 'firmalife:raw_honey'])
+	event.recipes.tfc.advanced_shapeless_crafting(TFC.isp.of('create:honeyed_apple').copyFood(), ['#tfc:foods/apples', 'firmalife:raw_honey'])
 	
 	event.recipes.gtceu.food_processor('create:honeyed_apple')
 		.itemInputs('#tfc:foods/apples', 'firmalife:raw_honey')
-		.itemOutputs(TFC.isp.of('create:honeyed_apple').resetFood())
+		.itemOutputs(TFC.isp.of('create:honeyed_apple').copyFood())
 		.circuit(5)
 		.duration(60)
 		.EUt(16)

--- a/kubejs/startup_scripts/create/constants.js
+++ b/kubejs/startup_scripts/create/constants.js
@@ -52,7 +52,6 @@ global.CREATE_DISABLED_ITEMS = [
     'create:bar_of_chocolate', 
     'create:sweet_roll', 
     'create:chocolate_glazed_berries', 
-    'create:honeyed_apple', 
     'create:builders_tea', 
     'create:andesite_alloy', 
     'create:chromatic_compound', 


### PR DESCRIPTION
## What is the new behavior?
Adds a crafting/food processor recipe for combining apples & raw honey for a preserved, higher-satiety apple using the Create item that is already in the game.

## Implementation Details
Removed create:honeyed_apple from disabled items list, added food details to data.food.js and tfc:foods/fruits tag.

## Outcome
New food item. The additional nutrition is similar to what is added in porridge with honey. Quick and simple to prepare, and rewards a player with a well-established base

## Additional Information
<img width="1180" height="475" alt="image" src="https://github.com/user-attachments/assets/97035875-7637-4ee4-b12b-d98a6e59841a" />
<img width="1053" height="599" alt="image" src="https://github.com/user-attachments/assets/68758bac-68d1-4be8-9e1e-5ee39a825b1d" />
<img width="1920" height="1009" alt="2026-04-01_13 45 12" src="https://github.com/user-attachments/assets/c10b9886-808e-4215-8f9a-bf294e0abe69" />
For comparison, apple jam is more efficient for bulk crafting, stores better, and can be used in sandwiches... but requires jars, which are a pain in the ass to make before industrialization.

## Potential Compatibility Issues
None that I know of...

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
Froffy