### PR TITLE
Train Component Cost Reduction

### DIFF
--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -17,7 +17,6 @@ const registerCreateRecipes = (event) => {
 			{ id: 'create:crafting/kinetics/linear_chassisfrom_conversion' },
 			{ id: 'create:crafting/kinetics/secondary_linear_chassisfrom_conversion' },
 			{ id: 'create:crafting/kinetics/portable_storage_interface' },
-			{ id: 'create:crafting/kinetics/track_signal' },
 			{ id: 'create:crafting/kinetics/track_observer' },
 			{ id: 'create:crafting/kinetics/controls' },
 			{ id: 'create:crafting/logistics/content_observer' },
@@ -73,6 +72,13 @@ const registerCreateRecipes = (event) => {
 	event.remove({ type: 'create:spout_filling', id: 'create:potions' })
 	event.remove({ type: 'create:spout_filling', id: 'create:fill_minecraft_glass_bottle_with_gtceu_potion' })
 	event.remove({ type: 'create:draining', id: 'create:potions' })
+
+	// Train Signal
+	event.shapeless('4x create:track_signal', [
+		'create:railway_casing',
+		'gtceu:glass_tube',
+		'#forge:dusts/glowstone'
+	]).id('create:crafting/kinetics/track_signal')
 
 	// Train Station
 	event.shapeless('2x create:track_station', [
@@ -718,11 +724,11 @@ const registerCreateRecipes = (event) => {
         .addMaterialInfo(true)
 
 	// Корпус поезда
-	event.recipes.createItemApplication(['create:railway_casing'], ['create:brass_casing', '#forge:plates/black_steel'])
+	event.recipes.createItemApplication(['create:railway_casing'], ['#forge:stripped_logs', '#forge:plates/steel'])
 		.id('tfg:create/item_application/railway_casing')
 
 	event.recipes.gtceu.assembler('tfg:create/railway_casing')
-		.itemInputs('create:brass_casing', '#forge:plates/black_steel')
+		.itemInputs('#forge:stripped_logs', '#forge:plates/steel')
 		.circuit(10)
 		.itemOutputs('create:railway_casing')
 		.duration(50)
@@ -2451,10 +2457,10 @@ const registerCreateRecipes = (event) => {
 	event.shapeless('2x create:copper_door', ['createdeco:copper_door', '#minecraft:wooden_doors', 'minecraft:glass_pane'])
 		.id('tfg:shapeless/create_copper_door')
 
-	event.shapeless('2x create:train_door', ['createdeco:industrial_iron_door', '#minecraft:wooden_doors', 'minecraft:glass_pane'])
+	event.shapeless('2x create:train_door', ['minecraft:iron_door', '#minecraft:wooden_doors', 'minecraft:glass_pane'])
 		.id('tfg:shapeless/create_train_door')
 
-	event.shapeless('2x create:train_trapdoor', ['tfc:metal/trapdoor/steel', '#minecraft:wooden_trapdoors'])
+	event.shapeless('2x create:train_trapdoor', ['tfc:metal/trapdoor/wrought_iron', '#minecraft:wooden_trapdoors'])
 		.id('tfg:shapeless/create_train_trapdoor')
 
 	// Fantasy stone blocks

--- a/kubejs/server_scripts/railways/recipes.js
+++ b/kubejs/server_scripts/railways/recipes.js
@@ -17,12 +17,12 @@ const registerRailWaysRecipes = (event) => {
 		A: '#forge:plates/wrought_iron',
 		B: '#minecraft:fences',
 		C: 'create:andesite_casing',
-		D: 'create:electron_tube',
+		D: '#forge:small_gears/red_alloy',
 		E: '#forge:tools/hammers',
 	}).id('tfg:railways/shaped/semaphore')
 
 	event.recipes.gtceu.assembler('tfg:railways/semaphore')
-		.itemInputs('2x #forge:plates/wrought_iron', '#minecraft:fences', 'create:andesite_casing', 'create:electron_tube')
+		.itemInputs('2x #forge:plates/wrought_iron', '#minecraft:fences', 'create:andesite_casing', '#forge:small_gears/red_alloy')
 		.circuit(3)
 		.itemOutputs('railways:semaphore')
 		.duration(200)
@@ -244,12 +244,12 @@ const registerRailWaysRecipes = (event) => {
 		A: 'create:fluid_tank',
 		B: 'create:railway_casing',
 		C: '#forge:tools/screwdrivers',
-		D: 'create:electron_tube',
+		D: '#forge:small_gears/brass',
 		E: 'firmalife:reinforced_glass',
 	}).id('tfg:railways/shaped/fuel_tank')
 
 	event.recipes.gtceu.assembler('tfg:railways/fuel_tank')
-		.itemInputs('create:fluid_tank', 'create:railway_casing', 'create:electron_tube', 'firmalife:reinforced_glass')
+		.itemInputs('create:fluid_tank', 'create:railway_casing', '#forge:small_gears/brass', 'firmalife:reinforced_glass')
 		.circuit(1)
 		.itemOutputs('railways:fuel_tank')
 		.duration(200)
@@ -502,19 +502,36 @@ const registerRailWaysRecipes = (event) => {
 
 	//#endregion
 
+	//#region Tracks
+
 	// Монорельс
 	event.recipes.createSequencedAssembly([
-		'6x railways:track_monorail',
+		'32x railways:track_monorail',
 	], 'create:metal_girder', [
 		event.recipes.createDeploying('railways:track_incomplete_monorail', ['railways:track_incomplete_monorail', '#forge:plates/wrought_iron']),
 		event.recipes.greate.pressing('railways:track_incomplete_monorail', 'railways:track_incomplete_monorail'),
 		event.recipes.createDeploying('railways:track_incomplete_monorail', ['railways:track_incomplete_monorail', '#forge:plates/wrought_iron']),
 		event.recipes.greate.pressing('railways:track_incomplete_monorail', 'railways:track_incomplete_monorail'),
-	]).transitionalItem('railways:track_incomplete_monorail').loops(1).id('tfg:railways/sequenced_assembly/track_monorail')
+	]).transitionalItem('railways:track_incomplete_monorail').loops(1).id('tfg:railways/sequenced_assembly/track_monorail/wrought_iron')
 
-	event.recipes.gtceu.assembler('railways/monorail')
+	event.recipes.gtceu.assembler('railways/monorail/wrought_iron')
 		.itemInputs('create:metal_girder', '2x #forge:plates/wrought_iron')
-		.itemOutputs('6x railways:track_monorail')
+		.itemOutputs('32x railways:track_monorail')
+		.duration(250)
+		.EUt(32)
+
+	event.recipes.createSequencedAssembly([
+		'64x railways:track_monorail',
+	], 'create:metal_girder', [
+		event.recipes.createDeploying('railways:track_incomplete_monorail', ['railways:track_incomplete_monorail', '#forge:plates/steel']),
+		event.recipes.greate.pressing('railways:track_incomplete_monorail', 'railways:track_incomplete_monorail'),
+		event.recipes.createDeploying('railways:track_incomplete_monorail', ['railways:track_incomplete_monorail', '#forge:plates/steel']),
+		event.recipes.greate.pressing('railways:track_incomplete_monorail', 'railways:track_incomplete_monorail'),
+	]).transitionalItem('railways:track_incomplete_monorail').loops(1).id('tfg:railways/sequenced_assembly/track_monorail/steel')
+
+	event.recipes.gtceu.assembler('railways/monorail/steel')
+		.itemInputs('create:metal_girder', '2x #forge:plates/steel')
+		.itemOutputs('64x railways:track_monorail')
 		.duration(250)
 		.EUt(32)
 
@@ -522,15 +539,31 @@ const registerRailWaysRecipes = (event) => {
 	event.recipes.createSequencedAssembly([
 		'16x railways:track_create_andesite_narrow',
 	], '#tfg:rock_slabs', [
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', 'gtceu:steel_rod']),
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#forge:rods/wrought_iron']),
 		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfc:mortar']),
 		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_narrow', 'railways:track_incomplete_create_andesite_narrow'),
-	]).transitionalItem('railways:track_incomplete_create_andesite_narrow').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_narrow_from_steel')
+	]).transitionalItem('railways:track_incomplete_create_andesite_narrow').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_narrow/wrought_iron')
 
-	event.recipes.gtceu.assembler('railways/track_create_andesite_narrow_from_steel')
+	event.recipes.gtceu.assembler('railways/track_create_andesite_narrow/wrought_iron')
 		.itemInputs('#tfg:rock_slabs', '2x gtceu:steel_rod')
 		.inputFluids(Fluid.of('gtceu:concrete', 144))
 		.itemOutputs('16x railways:track_create_andesite_narrow')
+		.duration(800)
+		.EUt(16)
+		.circuit(1)
+
+	event.recipes.createSequencedAssembly([
+		'32x railways:track_create_andesite_narrow',
+	], '#tfg:rock_slabs', [
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#forge:rods/steel']),
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfc:mortar']),
+		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_narrow', 'railways:track_incomplete_create_andesite_narrow'),
+	]).transitionalItem('railways:track_incomplete_create_andesite_narrow').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_narrow/steel')
+
+	event.recipes.gtceu.assembler('railways/track_create_andesite_narrow/steel')
+		.itemInputs('#tfg:rock_slabs', '2x #forge:rods/steel')
+		.inputFluids(Fluid.of('gtceu:concrete', 144))
+		.itemOutputs('32x railways:track_create_andesite_narrow')
 		.duration(800)
 		.EUt(16)
 		.circuit(1)
@@ -540,15 +573,32 @@ const registerRailWaysRecipes = (event) => {
 		'16x create:track',
 	], '#tfg:rock_slabs', [
 		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:rock_slabs']),
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', 'gtceu:steel_rod']),
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#forge:rods/wrought_iron']),
 		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfc:mortar']),
 		event.recipes.greate.pressing('railways:track_incomplete_blackstone', 'railways:track_incomplete_blackstone'),
-	]).transitionalItem('railways:track_incomplete_blackstone').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite')
+	]).transitionalItem('railways:track_incomplete_blackstone').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite/wrought_iron')
 
-	event.recipes.gtceu.assembler('railways/track')
-		.itemInputs('3x #tfg:rock_slabs', '2x gtceu:steel_rod')
+	event.recipes.gtceu.assembler('railways/track/wrought_iron')
+		.itemInputs('3x #tfg:rock_slabs', '2x #forge:rods/wrought_iron')
 		.inputFluids(Fluid.of('gtceu:concrete', 144))
 		.itemOutputs('16x create:track')
+		.duration(800)
+		.EUt(16)
+		.circuit(2)
+
+	event.recipes.createSequencedAssembly([
+		'32x create:track',
+	], '#tfg:rock_slabs', [
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:rock_slabs']),
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#forge:rods/steel']),
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfc:mortar']),
+		event.recipes.greate.pressing('railways:track_incomplete_blackstone', 'railways:track_incomplete_blackstone'),
+	]).transitionalItem('railways:track_incomplete_blackstone').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite/steel')
+
+	event.recipes.gtceu.assembler('railways/track/steel')
+		.itemInputs('3x #tfg:rock_slabs', '2x #forge:rods/steel')
+		.inputFluids(Fluid.of('gtceu:concrete', 144))
+		.itemOutputs('32x create:track')
 		.duration(800)
 		.EUt(16)
 		.circuit(2)
@@ -558,15 +608,32 @@ const registerRailWaysRecipes = (event) => {
 		'16x railways:track_create_andesite_wide',
 	], '#tfg:rock_slabs', [
 		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#forge:stone']),
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', 'gtceu:steel_rod']),
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#forge:rods/wrought_iron']),
 		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfc:mortar']),
 		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_wide', 'railways:track_incomplete_create_andesite_wide'),
-	]).transitionalItem('railways:track_incomplete_create_andesite_wide').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_wide')
+	]).transitionalItem('railways:track_incomplete_create_andesite_wide').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_wide/wrought_iron')
 
-	event.recipes.gtceu.assembler('railways/track_create_andesite_wide')
-		.itemInputs('5x #tfg:rock_slabs', '2x gtceu:steel_rod')
+	event.recipes.gtceu.assembler('railways/track_create_andesite_wide/wrought_iron')
+		.itemInputs('5x #tfg:rock_slabs', '2x #forge:rods/wrought_iron')
 		.inputFluids(Fluid.of('gtceu:concrete', 144))
 		.itemOutputs('16x railways:track_create_andesite_wide')
+		.duration(800)
+		.EUt(16)
+		.circuit(3)
+
+	event.recipes.createSequencedAssembly([
+		'32x railways:track_create_andesite_wide',
+	], '#tfg:rock_slabs', [
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#forge:stone']),
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#forge:rods/steel']),
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfc:mortar']),
+		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_wide', 'railways:track_incomplete_create_andesite_wide'),
+	]).transitionalItem('railways:track_incomplete_create_andesite_wide').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_wide/steel')
+
+	event.recipes.gtceu.assembler('railways/track_create_andesite_wide/steel')
+		.itemInputs('5x #tfg:rock_slabs', '2x #forge:rods/steel')
+		.inputFluids(Fluid.of('gtceu:concrete', 144))
+		.itemOutputs('32x railways:track_create_andesite_wide')
 		.duration(800)
 		.EUt(16)
 		.circuit(3)
@@ -577,14 +644,29 @@ const registerRailWaysRecipes = (event) => {
 		event.recipes.createSequencedAssembly([
 			`16x railways:track_tfc_${woodType}_narrow`,
 		], `tfc:wood/planks/${woodType}_slab`, [
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, 'gtceu:steel_rod']),
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#forge:rods/wrought_iron']),
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#forge:screws']),
 			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}_narrow`, `railways:track_incomplete_tfc_${woodType}_narrow`),
-		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_narrow`)
+		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_narrow/wrought_iron`)
 
-		event.recipes.gtceu.assembler(`railways/track_create_${woodType}_narrow`)
-			.itemInputs(`tfc:wood/planks/${woodType}_slab`, '2x gtceu:steel_rod', '2x #forge:screws')
+		event.recipes.gtceu.assembler(`railways/track_create_${woodType}_narrow/wrought_iron`)
+			.itemInputs(`tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/wrought_iron', '2x #forge:screws')
 			.itemOutputs(`16x railways:track_tfc_${woodType}_narrow`)
+			.duration(800)
+			.EUt(16)
+			.circuit(1)
+
+		event.recipes.createSequencedAssembly([
+			`32x railways:track_tfc_${woodType}_narrow`,
+		], `tfc:wood/planks/${woodType}_slab`, [
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#forge:rods/steel']),
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#forge:screws']),
+			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}_narrow`, `railways:track_incomplete_tfc_${woodType}_narrow`),
+		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_narrow/steel`)
+
+		event.recipes.gtceu.assembler(`railways/track_create_${woodType}_narrow/steel`)
+			.itemInputs(`tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/steel', '2x #forge:screws')
+			.itemOutputs(`32x railways:track_tfc_${woodType}_narrow`)
 			.duration(800)
 			.EUt(16)
 			.circuit(1)
@@ -594,14 +676,30 @@ const registerRailWaysRecipes = (event) => {
 			`16x railways:track_tfc_${woodType}`,
 		], `tfc:wood/planks/${woodType}_slab`, [
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, `tfc:wood/lumber/${woodType}`]),
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, 'gtceu:steel_rod']),
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, '#forge:rods/wrought_iron']),
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, '#forge:screws']),
 			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}`, `railways:track_incomplete_tfc_${woodType}`),
-		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}`)
+		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}/wrought_iron`)
 
-		event.recipes.gtceu.assembler(`railways/track_${woodType}`)
-			.itemInputs(`tfc:wood/planks/${woodType}_slab`, `2x tfc:wood/lumber/${woodType}`, '2x gtceu:steel_rod', '2x #forge:screws')
+		event.recipes.gtceu.assembler(`railways/track_${woodType}/wrought_iron`)
+			.itemInputs(`tfc:wood/planks/${woodType}_slab`, `2x tfc:wood/lumber/${woodType}`, '2x #forge:rods/wrought_iron', '2x #forge:screws')
 			.itemOutputs(`16x railways:track_tfc_${woodType}`)
+			.duration(800)
+			.EUt(16)
+			.circuit(2)
+
+		event.recipes.createSequencedAssembly([
+			`32x railways:track_tfc_${woodType}`,
+		], `tfc:wood/planks/${woodType}_slab`, [
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, `tfc:wood/lumber/${woodType}`]),
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, '#forge:rods/steel']),
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, '#forge:screws']),
+			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}`, `railways:track_incomplete_tfc_${woodType}`),
+		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}/steel`)
+
+		event.recipes.gtceu.assembler(`railways/track_${woodType}/steel`)
+			.itemInputs(`tfc:wood/planks/${woodType}_slab`, `2x tfc:wood/lumber/${woodType}`, '2x #forge:rods/steel', '2x #forge:screws')
+			.itemOutputs(`32x railways:track_tfc_${woodType}`)
 			.duration(800)
 			.EUt(16)
 			.circuit(2)
@@ -611,14 +709,30 @@ const registerRailWaysRecipes = (event) => {
 			`16x railways:track_tfc_${woodType}_wide`,
 		], `tfc:wood/planks/${woodType}_slab`, [
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, `tfc:wood/planks/${woodType}_slab`]),
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, `gtceu:steel_rod`]),
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, `#forge:rods/wrought_iron`]),
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, '#forge:screws']),
 			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}_wide`, `railways:track_incomplete_tfc_${woodType}_wide`)
-		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_wide`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_wide`)
+		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_wide`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_wide/wrought_iron`)
 
-		event.recipes.gtceu.assembler(`railways/track_${woodType}_wide`)
-			.itemInputs(`3x tfc:wood/planks/${woodType}_slab`, '2x gtceu:steel_rod', '2x #forge:screws')
+		event.recipes.gtceu.assembler(`railways/track_${woodType}_wide/wrought_iron`)
+			.itemInputs(`3x tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/wrought_iron', '2x #forge:screws')
 			.itemOutputs(`16x railways:track_tfc_${woodType}_wide`)
+			.duration(800)
+			.EUt(16)
+			.circuit(3)
+
+		event.recipes.createSequencedAssembly([
+			`32x railways:track_tfc_${woodType}_wide`,
+		], `tfc:wood/planks/${woodType}_slab`, [
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, `tfc:wood/planks/${woodType}_slab`]),
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, `#forge:rods/steel`]),
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, '#forge:screws']),
+			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}_wide`, `railways:track_incomplete_tfc_${woodType}_wide`)
+		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_wide`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_wide/steel`)
+
+		event.recipes.gtceu.assembler(`railways/track_${woodType}_wide/steel`)
+			.itemInputs(`3x tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/steel', '2x #forge:screws')
+			.itemOutputs(`32x railways:track_tfc_${woodType}_wide`)
 			.duration(800)
 			.EUt(16)
 			.circuit(3)
@@ -642,15 +756,31 @@ const registerRailWaysRecipes = (event) => {
 		event.recipes.createSequencedAssembly([
 			`16x railways:track_${x.rail}_narrow`,
 		], x.slab, [
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_narrow`, [`railways:track_incomplete_${x.rail}_narrow`, `gtceu:steel_rod`]),
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_narrow`, [`railways:track_incomplete_${x.rail}_narrow`, `#forge:rods/wrought_iron`]),
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_narrow`, [`railways:track_incomplete_${x.rail}_narrow`, `#tfc:mortar`]),
 			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}_narrow`, `railways:track_incomplete_${x.rail}_narrow`),
-		]).transitionalItem(`railways:track_incomplete_${x.rail}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_narrow_alt`)
+		]).transitionalItem(`railways:track_incomplete_${x.rail}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_narrow_alt/wrought_iron`)
 
-		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_narrow_alt`)
-			.itemInputs(x.slab, `2x gtceu:steel_rod`)
+		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_narrow_alt/wrought_iron`)
+			.itemInputs(x.slab, `2x #forge:rods/wrought_iron`)
 			.inputFluids(Fluid.of(`gtceu:concrete`, 144))
 			.itemOutputs(`16x railways:track_${x.rail}_narrow`)
+			.duration(800)
+			.EUt(16)
+			.circuit(1)
+
+		event.recipes.createSequencedAssembly([
+			`32x railways:track_${x.rail}_narrow`,
+		], x.slab, [
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_narrow`, [`railways:track_incomplete_${x.rail}_narrow`, `#forge:rods/steel`]),
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_narrow`, [`railways:track_incomplete_${x.rail}_narrow`, `#tfc:mortar`]),
+			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}_narrow`, `railways:track_incomplete_${x.rail}_narrow`),
+		]).transitionalItem(`railways:track_incomplete_${x.rail}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_narrow_alt/steel`)
+
+		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_narrow_alt/steel`)
+			.itemInputs(x.slab, `2x #forge:rods/steel`)
+			.inputFluids(Fluid.of(`gtceu:concrete`, 144))
+			.itemOutputs(`32x railways:track_${x.rail}_narrow`)
 			.duration(800)
 			.EUt(16)
 			.circuit(1)
@@ -659,15 +789,32 @@ const registerRailWaysRecipes = (event) => {
 			`16x railways:track_${x.rail}`,
 		], x.slab, [
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, x.slab]),
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, `gtceu:steel_rod`]),
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, `#forge:rods/wrought_iron`]),
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, `#tfc:mortar`]),
 			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}`, `railways:track_incomplete_${x.rail}`),
-		]).transitionalItem(`railways:track_incomplete_${x.rail}`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_alt`)
+		]).transitionalItem(`railways:track_incomplete_${x.rail}`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_alt/wrought_iron`)
 
-		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_normal_alt`)
-			.itemInputs(`3x ${x.slab}`, `2x gtceu:steel_rod`)
+		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_normal_alt/wrought_iron`)
+			.itemInputs(`3x ${x.slab}`, `2x #forge:rods/wrought_iron`)
 			.inputFluids(Fluid.of(`gtceu:concrete`, 144))
 			.itemOutputs(`16x railways:track_${x.rail}`)
+			.duration(800)
+			.EUt(16)
+			.circuit(2)
+			
+		event.recipes.createSequencedAssembly([
+			`32x railways:track_${x.rail}`,
+		], x.slab, [
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, x.slab]),
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, `#forge:rods/steel`]),
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, `#tfc:mortar`]),
+			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}`, `railways:track_incomplete_${x.rail}`),
+		]).transitionalItem(`railways:track_incomplete_${x.rail}`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_alt/steel`)
+
+		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_normal_alt/steel`)
+			.itemInputs(`3x ${x.slab}`, `2x #forge:rods/steel`)
+			.inputFluids(Fluid.of(`gtceu:concrete`, 144))
+			.itemOutputs(`32x railways:track_${x.rail}`)
 			.duration(800)
 			.EUt(16)
 			.circuit(2)
@@ -676,15 +823,32 @@ const registerRailWaysRecipes = (event) => {
 			`16x railways:track_${x.rail}_wide`,
 		], x.slab, [
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, x.block]),
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, `gtceu:steel_rod`]),
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, `#forge:rods/wrought_iron`]),
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, `#tfc:mortar`]),
 			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}_wide`, `railways:track_incomplete_${x.rail}_wide`),
-		]).transitionalItem(`railways:track_incomplete_${x.rail}_wide`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_wide_alt`)
+		]).transitionalItem(`railways:track_incomplete_${x.rail}_wide`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_wide_alt/wrought_iron`)
 
-		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_wide_alt`)
-			.itemInputs(`5x ${x.slab}`, `2x gtceu:steel_rod`)
+		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_wide_alt/wrought_iron`)
+			.itemInputs(`5x ${x.slab}`, `2x #forge:rods/wrought_iron`)
 			.inputFluids(Fluid.of(`gtceu:concrete`, 144))
 			.itemOutputs(`16x railways:track_${x.rail}_wide`)
+			.duration(800)
+			.EUt(16)
+			.circuit(3)
+
+		event.recipes.createSequencedAssembly([
+			`32x railways:track_${x.rail}_wide`,
+		], x.slab, [
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, x.block]),
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, `#forge:rods/steel`]),
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, `#tfc:mortar`]),
+			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}_wide`, `railways:track_incomplete_${x.rail}_wide`),
+		]).transitionalItem(`railways:track_incomplete_${x.rail}_wide`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_wide_alt/steel`)
+
+		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_wide_alt/steel`)
+			.itemInputs(`5x ${x.slab}`, `2x #forge:rods/steel`)
+			.inputFluids(Fluid.of(`gtceu:concrete`, 144))
+			.itemOutputs(`32x railways:track_${x.rail}_wide`)
 			.duration(800)
 			.EUt(16)
 			.circuit(3)
@@ -698,6 +862,8 @@ const registerRailWaysRecipes = (event) => {
 
 	event.shapeless('8x railways:track_phantom', ['#forge:small_dusts/ender_pearl', '8x create:track'])
 		.id('tfg:shapeless/phantom_tracks')
+
+	//#endregion
 
 	event.shaped('1x railways:handcar', [
 		'EFE',


### PR DESCRIPTION
### What is the new behavior?
Train components and functional blocks are now cheaper - no longer requiring black steel and electron tubes. Also, tracks now have wrought iron and steel recipes with an improved output amount.

### Implementation Details
- Train Casing now requires a stripped log and a steel plate.
- Train Signal now takes a glass tube and glowstone dust instead of an electron tube.
- Semaphore now takes a red alloy gear instead of an electron tube.
- Fuel Tank now takes a brass gear instead of an electron tube.
- 16x Tracks when made out of wrought iron.
- 32x Tracks when made out of steel.
- 32x Monorails when crafted out of wrought iron.
- 64x Monorails when crafted out of steel.

### Additional Information
- Closes #3579