### PR TITLE
Add UDP port for simple voice chat in Docker Compose

### DIFF
--- a/.pakku/docker-overrides/docker-compose.yml
+++ b/.pakku/docker-overrides/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     stdin_open: true
     ports:
       - "25565:25565"
+      - "24454:24454/udp" # simple voice chat
     environment:
       EULA: "true"
       ENABLE_RCON: "false"


### PR DESCRIPTION
## What is the new behavior?
Since version 0.11.28 simple voice chat is part of the modpack. It requires the server owner to expose port 24454/udp. [[1]](https://modrepo.de/minecraft/voicechat/wiki/server_setup_self_hosted#on-a-vps-or-root-server) 

## Implementation Details
None, except maybe mentioning in the docs to server owners that they should also enable inbound traffic port 24454/udp in their firewall, if they wish to use simple voice chat. Since I didn't find any server owner docs, I didn't include such documentation in this PR.

## Outcome
It adds the port mapping in the docker compose.


Discord Nickname: konradzuse

[1] https://modrepo.de/minecraft/voicechat/wiki/server_setup_self_hosted#on-a-vps-or-root-server