### PR TITLE
Large Nest Box Dupe Fix

### DIFF
--- a/kubejs/server_scripts/tfg/loot.js
+++ b/kubejs/server_scripts/tfg/loot.js
@@ -88,6 +88,17 @@ function registerTFGLoots(event) {
 		.removeLoot(Ingredient.all)
 		.addLoot('minecraft:campfire')
 
+	event.addBlockLootModifier('tfg:large_nest_box')
+		.removeLoot('tfg:large_nest_box')
+		.customCondition({
+				block: "tfg:large_nest_box",
+				condition: "minecraft:block_state_property",
+				properties: {
+					nest_part: "0"
+				}
+			})
+		.addLoot('tfg:large_nest_box')
+
 	//#endregion
 
 	//Cross-mod glass compat


### PR DESCRIPTION
### What is the new behavior?
Fixes large nest box duplication.

### Implementation Details
- Removed the loot and re-added it with a condition (just adding a condition didn't work).

### Additional Information
- Fixes #3730