### PR TITLE
Add Crafting Stations

### DIFF
--- a/kubejs/server_scripts/tfg/primitive/recipes.wood.js
+++ b/kubejs/server_scripts/tfg/primitive/recipes.wood.js
@@ -94,4 +94,17 @@ function registerTFGWoodRecipes(event) {
 		.duration(20)
 		.circuit(6)
 		.EUt(GTValues.VA[GTValues.LV])
+
+		// Crafting Station
+		event.shaped('craftingstation:crafting_station', [
+			'BCB',
+			'ADA',
+			'AEA'
+	], {
+			A: '#tfc:lumber',
+			B: '#forge:screws/any_bronze', 
+			C: '#tfc:workbenches',
+			D: '#forge:tools/saws', 
+			E: '#forge:tools/hammers' 
+	}).id('craftingstation:shaped/crafting_station')
 }

--- a/pakku-lock.json
+++ b/pakku-lock.json
@@ -3640,6 +3640,35 @@
             ]
         },
         {
+            "pakku_id": "ab7eDpfo6vN30Jcm",
+            "type": "MOD",
+            "slug": {
+                "github": "Deepacat/Crafting-station-improved"
+            },
+            "name": {
+                "github": "Crafting-station-improved"
+            },
+            "id": {
+                "github": "1022822186"
+            },
+            "redistributable": false,
+            "files": [
+                {
+                    "type": "github",
+                    "file_name": "craftingstation-1.20.1-1.3.3.jar",
+                    "release_type": "release",
+                    "url": "https://github.com/Deepacat/Crafting-station-improved/releases/download/1.3.3/craftingstation-1.20.1-1.3.3.jar",
+                    "id": "336082764",
+                    "parent_id": "1022822186",
+                    "hashes": {
+                        "sha256": "c768f5d211f4e374f6cc7cf3bf034a6dd41247d2c3378a7bd39e296fa1561b97"
+                    },
+                    "size": 93034,
+                    "date_published": "2026-01-04T05:44:01Z"
+                }
+            ]
+        },
+        {
             "pakku_id": "lePQHTl9cI4dUuqu",
             "type": "MOD",
             "side": "CLIENT",

--- a/pakku-lock.json
+++ b/pakku-lock.json
@@ -3573,6 +3573,43 @@
             ]
         },
         {
+            "pakku_id": "NjMvB56e9BwKGMLj",
+            "type": "MOD",
+            "slug": {
+                "curseforge": "crafting-station-improved"
+            },
+            "name": {
+                "curseforge": "Crafting Station Improved"
+            },
+            "id": {
+                "curseforge": "1310299"
+            },
+            "files": [
+                {
+                    "type": "curseforge",
+                    "file_name": "craftingstation-1.20.1-1.3.3.jar",
+                    "mc_versions": [
+                        "1.20.1"
+                    ],
+                    "loaders": [
+                        "forge",
+                        "neoforge"
+                    ],
+                    "release_type": "release",
+                    "url": "https://edge.forgecdn.net/files/7463/65/craftingstation-1.20.1-1.3.3.jar",
+                    "id": "7463065",
+                    "parent_id": "1310299",
+                    "hashes": {
+                        "sha1": "14042cc0680f7401b22cb7786001ffcc152f2685",
+                        "md5": "08cb0e0a33fc272bdf7caf3ebdc29e50"
+                    },
+                    "required_dependencies": [],
+                    "size": 93034,
+                    "date_published": "2026-01-15T10:55:32.653Z"
+                }
+            ]
+        },
+        {
             "pakku_id": "iVxwBkSQPuiTe33a",
             "type": "MOD",
             "side": "BOTH",
@@ -3636,35 +3673,6 @@
                     ],
                     "size": 231043,
                     "date_published": "2026-01-13T13:10:45.682500Z"
-                }
-            ]
-        },
-        {
-            "pakku_id": "ab7eDpfo6vN30Jcm",
-            "type": "MOD",
-            "slug": {
-                "github": "Deepacat/Crafting-station-improved"
-            },
-            "name": {
-                "github": "Crafting-station-improved"
-            },
-            "id": {
-                "github": "1022822186"
-            },
-            "redistributable": false,
-            "files": [
-                {
-                    "type": "github",
-                    "file_name": "craftingstation-1.20.1-1.3.3.jar",
-                    "release_type": "release",
-                    "url": "https://github.com/Deepacat/Crafting-station-improved/releases/download/1.3.3/craftingstation-1.20.1-1.3.3.jar",
-                    "id": "336082764",
-                    "parent_id": "1022822186",
-                    "hashes": {
-                        "sha256": "c768f5d211f4e374f6cc7cf3bf034a6dd41247d2c3378a7bd39e296fa1561b97"
-                    },
-                    "size": 93034,
-                    "date_published": "2026-01-04T05:44:01Z"
                 }
             ]
         },

--- a/pakku-lock.json
+++ b/pakku-lock.json
@@ -3581,6 +3581,30 @@
             },
             "id": {
                 "curseforge": "1310299"
+            }
+            "files": [
+                {
+                    "file_name": "craftingstation-1.20.1-1.3.3.jar",
+                    "mc_versions": [
+                        "1.20.1"
+                    ],
+                    "loaders": [
+                        "forge",
+                        "neoforge"
+                    ],
+                    "release_type": "release",
+                    "url": "https://edge.forgecdn.net/files/7463/65/craftingstation-1.20.1-1.3.3.jar",
+                    "id": "7463065",
+                    "parent_id": "1310299",
+                    "hashes": {
+                        "sha1": "14042cc0680f7401b22cb7786001ffcc152f2685",
+                        "md5": "08cb0e0a33fc272bdf7caf3ebdc29e50"
+                },
+                "required_dependencies": [],
+                "size": 93034,
+                "date_published": "2026-01-15T10:55:32.653Z"
+        },
+        {
             "pakku_id": "pYeN3mBUsIkhMt5w",
             "type": "MOD",
             "side": "CLIENT",
@@ -3599,25 +3623,6 @@
             "files": [
                 {
                     "type": "curseforge",
-                    "file_name": "craftingstation-1.20.1-1.3.3.jar",
-                    "mc_versions": [
-                        "1.20.1"
-                    ],
-                    "loaders": [
-                        "forge",
-                        "neoforge"
-                    ],
-                    "release_type": "release",
-                    "url": "https://edge.forgecdn.net/files/7463/65/craftingstation-1.20.1-1.3.3.jar",
-                    "id": "7463065",
-                    "parent_id": "1310299",
-                    "hashes": {
-                        "sha1": "14042cc0680f7401b22cb7786001ffcc152f2685",
-                        "md5": "08cb0e0a33fc272bdf7caf3ebdc29e50"
-                    },
-                    "required_dependencies": [],
-                    "size": 93034,
-                    "date_published": "2026-01-15T10:55:32.653Z"
                     "file_name": "cosycritters-0.3.2+1.20.1-forge.jar",
                     "mc_versions": [
                         "1.20.1",


### PR DESCRIPTION
## What is the new behavior?

#3673

## Implementation Details
The mod itself doesn't seem to come with a recipe, so I don't think I needed to remove it. Also, I wasn't really sure where to put the recipe, so I went with primitive/recipes.wood.js 

## Outcome
Adds crafting stations, a bronze-age crafting table that allows you to access items from adjacent storage inventories.

## Additional Information
<img width="789" height="570" alt="image" src="https://github.com/user-attachments/assets/18485c80-13c1-420a-96e5-f37e61d71dd1" />



**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
Froffy