### PR TITLE
adds #bee_nature_restoration to some tfg flowers

### DIFF
--- a/kubejs/server_scripts/firmalife/tags.js
+++ b/kubejs/server_scripts/firmalife/tags.js
@@ -30,20 +30,6 @@ const registerFirmaLifeItemTags = (event) => {
 
     event.add('tfc:clay_recycle_5', '#firmalife:clay_recycle_5')
 
-    event.add('firmalife:rest')
-
-    event.add('firmalife:bee_restoration_plants', 'tfg:plant/azalea')    
-    event.add('firmalife:bee_restoration_plants', 'tfg:plant/buttercup')
-    event.add('firmalife:bee_restoration_plants', 'tfg:plant/cornflower')
-    event.add('firmalife:bee_restoration_plants', 'tfc:plant/rose')
-    event.add('firmalife:bee_restoration_plants', 'tfc:plant/hibiscus')
-    event.add('firmalife:bee_restoration_plants', 'tfg:plant/mountain_hullwort')
-    event.add('firmalife:bee_restoration_plants', 'tfg:plant/palash')
-    event.add('firmalife:bee_restoration_plants', 'tfg:plant/penwortel')
-    event.add('firmalife:bee_restoration_plants', 'tfg:plant/qantu')
-    event.add('firmalife:bee_restoration_plants', 'tfg:plant/ramirezella')
-    event.add('firmalife:bee_restoration_plants', 'tfg:plant/ramunda')
-    event.add('firmalife:bee_restoration_plants', 'tfg:plant/yellow_saxifrage')
 }
 
 const registerFirmaLifeBlockTags = (event) => {
@@ -92,6 +78,20 @@ const registerFirmaLifeBlockTags = (event) => {
 
     event.add('firmalife:oven_insulation', 'firmalife:stovetop_pot');
     event.add('firmalife:oven_insulation', 'firmalife:vat');
+
+    // tfg and a few missed(?) tfc flowers for bee restoration
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/azalea')    
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/buttercup')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/cornflower')
+    event.add('firmalife:bee_restoration_plants', 'tfc:plant/rose')
+    event.add('firmalife:bee_restoration_plants', 'tfc:plant/hibiscus')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/mountain_hullwort')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/palash')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/penwortel')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/qantu')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/ramirezella')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/ramunda')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/yellow_saxifrage')
 }
 
 const registerFirmaLifeFluidTags = (event) => {

--- a/kubejs/server_scripts/firmalife/tags.js
+++ b/kubejs/server_scripts/firmalife/tags.js
@@ -83,6 +83,7 @@ const registerFirmaLifeBlockTags = (event) => {
     event.add('firmalife:bee_restoration_plants', 'tfg:plant/azalea')    
     event.add('firmalife:bee_restoration_plants', 'tfg:plant/buttercup')
     event.add('firmalife:bee_restoration_plants', 'tfg:plant/cornflower')
+	event.add('firmalife:bee_restoration_plants', 'tfg:plant/edelweiss')
     event.add('firmalife:bee_restoration_plants', 'tfc:plant/rose')
     event.add('firmalife:bee_restoration_plants', 'tfc:plant/hibiscus')
     event.add('firmalife:bee_restoration_plants', 'tfg:plant/mountain_hullwort')

--- a/kubejs/server_scripts/firmalife/tags.js
+++ b/kubejs/server_scripts/firmalife/tags.js
@@ -29,6 +29,21 @@ const registerFirmaLifeItemTags = (event) => {
     event.add('minecraft:leaves', 'firmalife:plant/fig_leaves')
 
     event.add('tfc:clay_recycle_5', '#firmalife:clay_recycle_5')
+
+    event.add('firmalife:rest')
+
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/azalea')    
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/buttercup')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/cornflower')
+    event.add('firmalife:bee_restoration_plants', 'tfc:plant/rose')
+    event.add('firmalife:bee_restoration_plants', 'tfc:plant/hibiscus')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/mountain_hullwort')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/palash')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/penwortel')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/qantu')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/ramirezella')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/ramunda')
+    event.add('firmalife:bee_restoration_plants', 'tfg:plant/yellow_saxifrage')
 }
 
 const registerFirmaLifeBlockTags = (event) => {

--- a/kubejs/server_scripts/tfg/overworld/tags.overworld.js
+++ b/kubejs/server_scripts/tfg/overworld/tags.overworld.js
@@ -55,6 +55,18 @@ function registerTFGOverworldItemTags(event) {
 	event.add('tfc:makes_white_dye', 'tfg:plant/edelweiss')
 	event.add('tfc:makes_white_dye', 'tfg:plant/bear_grass')
 	event.add('tfc:makes_light_gray_dye', 'tfg:plant/silver_bromeliad')
+
+	event.add('minecraft:flowers', 'tfg:plant/azalea')
+	event.add('minecraft:flowers', 'tfg:plant/buttercup')
+	event.add('minecraft:flowers', 'tfg:plant/cornflower')
+	event.add('minecraft:flowers', 'tfg:plant/edelweiss')
+	event.add('minecraft:flowers', 'tfg:plant/mountain_hullwort')
+	event.add('minecraft:flowers', 'tfg:plant/palash')
+	event.add('minecraft:flowers', 'tfg:plant/penwortel')
+	event.add('minecraft:flowers', 'tfg:plant/qantu')
+	event.add('minecraft:flowers', 'tfg:plant/ramirezella')
+	event.add('minecraft:flowers', 'tfg:plant/ramunda')
+	event.add('minecraft:flowers', 'tfg:plant/yellow_saxifrage')
 }
 
 function registerTFGOverworldBlockTags(event) {


### PR DESCRIPTION
## What is the new behavior?
adds #firmalife/bee_nature_restoration and #minecraft/flowers to some tfg flowers. restoration is also added to some tfc flowers that i think were missed in base firmalife!

## Implementation Details
let me know if i missed any obvious flowers or if we want like cacti and mosses and all the other stuff too :D

fixes: #3729 

## Outcome
these plants now have the #firmalife/bee_nature_restoration tag and should spawn near bees with the nature restoration trait:

- azalea
- buttercup
- cornflower
- edelweiss
- rose
- hibiscus
- mountain hullwort
- palash
- penwortel
- qantu
- ramirezella
- ramunda
- yellow saxifrage 

## Additional Information
btw has anyone ever seen a naturally spawning rose bush? ive looked everywhere...

<img width="564" height="924" alt="image" src="https://github.com/user-attachments/assets/2b31c072-de89-4b9f-bcc6-05468dfbb95e" />


## Potential Compatibility Issues
too many plants might dilute the plant pool and make individual plants or particular spices harder to acquire, but i think if you're using bees you'll probably be breeding several nests anyway. my single lvl 6 nest has made enough for me to get all the spices in a month or so!

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
Froffy