### PR TITLE
New Distinct Crafting Station Recipes

### DIFF
--- a/config/additionalplacements-startup.toml
+++ b/config/additionalplacements-startup.toml
@@ -14,7 +14,16 @@
 			[startup.types.additionalplacements.slab]
 				#Blocklist for controlling which blocks (that are valid for this type) will generate variants of this type
 				#See https://github.com/FirEmerald/AdditionalPlacements/wiki/Blocklist-Format for blocklist format
-				enabled = ["+*", "-rnr:roof_frame_slab"]
+				enabled = ["+*", "-rnr:roof_frame_slab", "-tfg:wood/crafting_station/araucaria_slab", "-tfg:wood/crafting_station/beech_slab", "-tfg:wood/crafting_station/mahoe_slab", 
+					"-tfg:wood/crafting_station/glacian_slab", "-tfg:wood/crafting_station/strophar_slab", "-tfg:wood/crafting_station/aeronos_slab", "-tfg:wood/crafting_station/ginkgo_slab", 
+					"-tfg:wood/crafting_station/baobab_slab", "-tfg:wood/crafting_station/eucalyptus_slab", "-tfg:wood/crafting_station/mahogany_slab", "-tfg:wood/crafting_station/hevea_slab", 
+					"-tfg:wood/crafting_station/tualang_slab", "-tfg:wood/crafting_station/teak_slab", "-tfg:wood/crafting_station/cypress_slab", "-tfg:wood/crafting_station/fig_slab", 
+					"-tfg:wood/crafting_station/ironwood_slab", "-tfg:wood/crafting_station/ipe_slab", "-tfg:wood/crafting_station/acacia_slab", "-tfg:wood/crafting_station/ash_slab", 
+					"-tfg:wood/crafting_station/aspen_slab", "-tfg:wood/crafting_station/birch_slab", "-tfg:wood/crafting_station/blackwood_slab", "-tfg:wood/crafting_station/chestnut_slab", 
+					"-tfg:wood/crafting_station/douglas_fir_slab", "-tfg:wood/crafting_station/hickory_slab", "-tfg:wood/crafting_station/kapok_slab", "-tfg:wood/crafting_station/mangrove_slab", 
+					"-tfg:wood/crafting_station/maple_slab", "-tfg:wood/crafting_station/oak_slab", "-tfg:wood/crafting_station/palm_slab", "-tfg:wood/crafting_station/pine_slab", 
+					"-tfg:wood/crafting_station/rosewood_slab", "-tfg:wood/crafting_station/sequoia_slab", "-tfg:wood/crafting_station/spruce_slab", "-tfg:wood/crafting_station/sycamore_slab", 
+					"-tfg:wood/crafting_station/white_cedar_slab", "-tfg:wood/crafting_station/willow_slab", "-tfg:wood/crafting_station/crimson_slab", "-tfg:wood/crafting_station/warped_slab" ]
 
 			#Stairs
 			[startup.types.additionalplacements.stairs]

--- a/kubejs/server_scripts/crafting_station/tags.js
+++ b/kubejs/server_scripts/crafting_station/tags.js
@@ -1,0 +1,9 @@
+// priority: 0
+"use strict";
+
+const registerCraftingStationBlockTags = (event) => {
+    event.removeAllTagsFrom('craftingstation:crafting_station')
+    event.removeAllTagsFrom('craftingstation:crafting_station_slab')
+	event.add('c:hidden_from_recipe_viewers', 'craftingstation:crafting_station')
+    event.add('c:hidden_from_recipe_viewers', 'craftingstation:crafting_station_slab')
+}

--- a/kubejs/server_scripts/main_server_script.js
+++ b/kubejs/server_scripts/main_server_script.js
@@ -103,6 +103,7 @@ ServerEvents.tags('block', event => {
 	registerTFGBlockTagsNuclear(event)
 	registerVintageImprovementsBlockTags(event)
 	registerWABBlockTags(event)
+	registerCraftingStationBlockTags(event)
 })
 
 /**

--- a/kubejs/server_scripts/tfg/data.js
+++ b/kubejs/server_scripts/tfg/data.js
@@ -361,7 +361,29 @@ function registerTFGItemSize(event) {
 	event.itemSize("create:honeyed_apple", "small", "light")
 
 	//Crafting Station
-	event.itemSize("craftingstation:crafting_station", "large", "heavy", "crafting_station");
+	global.TFG_NEW_WOOD_TYPES.forEach(wood => { 
+		event.itemSize(`tfg:wood/crafting_station/${wood.name}`, "large", "heavy", `${wood.name}_crafting_station`);
+	})
+
+	global.WAB_WOOD.forEach(wood => { 
+		event.itemSize(`tfg:wood/crafting_station/${wood.name}`, "large", "heavy", `${wood.name}_crafting_station`);
+	})
+
+	global.AD_ASTRA_WOOD.forEach(wood => { 
+		event.itemSize(`tfg:wood/crafting_station/${wood.name}`, "large", "heavy", `${wood.name}_crafting_station`);
+	})
+
+	global.BENEATH_WOOD_TYPES.forEach(wood => { 
+		event.itemSize(`tfg:wood/crafting_station/${wood.name}`, "large", "heavy", `${wood.name}_crafting_station`);
+	})
+
+	global.AFC_WOOD_TYPES.forEach(wood => { 
+		event.itemSize(`tfg:wood/crafting_station/${wood.name}`, "large", "heavy", `${wood.name}_crafting_station`);
+	})
+
+	global.TFC_WOOD_TYPES.forEach(wood => { 
+		event.itemSize(`tfg:wood/crafting_station/${wood.name}`, "large", "heavy", `${wood.name}_crafting_station`);
+	})
 }
 
 //#endregion

--- a/kubejs/server_scripts/tfg/natural_blocks/recipes.wood.js
+++ b/kubejs/server_scripts/tfg/natural_blocks/recipes.wood.js
@@ -36,7 +36,7 @@ function registerTFGWoodenRecipes(event) {
         function TFGWoodBuilder(event, name, lumber, logs, log, stripped_log, plank, stair, slab, door, trapdoor, fence, log_fence,
             fence_gate, support, pressure_plate, button, log_wood, stripped_wood, tool_rack, workbench, bookshelf, chest, trapped_chest, 
             loom, sluice, barrel, lectern, scribing_table, sewing_table, jar_shelf, food_shelf, hanger, jarbnet, big_barrel, 
-            stomping_barrel, barrel_press, wine_shelf, sign, hanging_sign) {
+            stomping_barrel, barrel_press, wine_shelf, sign, hanging_sign, crafting_station, workbench_as_material) {
 
             // Stripped log from log
                 if (log && stripped_log && name) {
@@ -517,7 +517,7 @@ function registerTFGWoodenRecipes(event) {
                         B: '#forge:rods/wooden'
                     })
                     .id(`tfg:shaped/${name}_sign`)
-                }
+                };
 
             // Hanging Sign
                 if (hanging_sign && lumber && name) {
@@ -530,8 +530,32 @@ function registerTFGWoodenRecipes(event) {
                         B: lumber
                     })
                     .id(`tfg:shaped/${name}_hanging_sign`)
-                }
-        };
+                };
+
+            // Crafting Station
+                if(crafting_station && lumber && workbench_as_material && name) {
+                    event.shaped(crafting_station, [
+		                'BCB',
+		                'ADA',
+		                'AEA'
+                    ], {
+		                A: lumber,
+		                B: '#forge:screws/any_bronze', 
+		                C: workbench_as_material,
+		                D: '#forge:tools/saws', 
+		                E: '#forge:tools/hammers' 
+                    }).id(`tfg:shaped/${name}_crafting_station`)
+
+                    event.shapeless(`2x ${crafting_station}_slab`, [ crafting_station ]).id(`tfg:shapeless/${name}_crafting_station_slab`)
+
+                    event.recipes.gtceu.assembler(`tfg:${name}_crafting_station`)
+		                .itemInputs(`4x ${lumber}`, '2x #forge:screws/any_bronze', workbench_as_material)
+		                .itemOutputs(crafting_station)
+		                .duration(20)
+		                .circuit(10)
+		                .EUt(GTValues.VA[GTValues.LV])
+                    };
+        }
 
     // #endregion
 
@@ -716,7 +740,9 @@ function registerTFGWoodenRecipes(event) {
                 `tfg:wood/barrel_press/${wood.name}`,
                 `tfg:wood/wine_shelf/${wood.name}`,
                 `tfg:wood/sign/${wood.name}`,
-                `tfg:wood/hanging_sign/${wood.name}`
+                `tfg:wood/hanging_sign/${wood.name}`,
+                `tfg:wood/crafting_station/${wood.name}`,
+                `tfg:wood/workbench/${wood.name}`
             )
         })
 
@@ -765,7 +791,9 @@ function registerTFGWoodenRecipes(event) {
                 `tfg:wood/barrel_press/${wood.name}`,
                 `tfg:wood/wine_shelf/${wood.name}`,
                 `wan_ancient_beasts:${wood.name}_sign`,
-                `wan_ancient_beasts:${wood.name}_hanging_sign`
+                `wan_ancient_beasts:${wood.name}_hanging_sign`,
+                `tfg:wood/crafting_station/${wood.name}`,
+                `tfg:wood/workbench/${wood.name}`
             )
         })
 
@@ -815,7 +843,9 @@ function registerTFGWoodenRecipes(event) {
                 `tfg:wood/barrel_press/${wood.name}`,
                 `tfg:wood/wine_shelf/${wood.name}`,
                 `tfg:wood/sign/${wood.name}`,
-                `tfg:wood/hanging_sign/${wood.name}`
+                `tfg:wood/hanging_sign/${wood.name}`,
+                `tfg:wood/crafting_station/${wood.name}`,
+                `tfg:wood/workbench/${wood.name}`
             );
         });
 
@@ -897,7 +927,9 @@ function registerTFGWoodenRecipes(event) {
                 null,
                 null,
                 null,
-                null
+                null,
+                `tfg:wood/crafting_station/${wood}`,
+                `beneath:wood/planks/${wood}_workbench`
             );
         });
 
@@ -970,7 +1002,9 @@ function registerTFGWoodenRecipes(event) {
                 null,
                 null,
                 null,
-                null
+                null,
+                `tfg:wood/crafting_station/${wood}`,
+                `afc:wood/planks/${wood}_workbench`
             );
         });
 
@@ -1154,7 +1188,9 @@ function registerTFGWoodenRecipes(event) {
                 null,
                 null,
                 null,
-                null
+                null,
+                `tfg:wood/crafting_station/${wood}`,
+                `tfc:wood/planks/${wood}_workbench`
             );
         });
 
@@ -1242,6 +1278,8 @@ function registerTFGWoodenRecipes(event) {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
             );
 
@@ -1290,6 +1328,8 @@ function registerTFGWoodenRecipes(event) {
                 'gtceu:treated_wood_pressure_plate', 
                 'gtceu:treated_wood_button', 
                 null, 
+                null,
+                null,
                 null,
                 null,
                 null,

--- a/kubejs/server_scripts/tfg/primitive/recipes.wood.js
+++ b/kubejs/server_scripts/tfg/primitive/recipes.wood.js
@@ -94,24 +94,4 @@ function registerTFGWoodRecipes(event) {
 		.duration(20)
 		.circuit(6)
 		.EUt(GTValues.VA[GTValues.LV])
-
-	// Crafting Station
-	event.shaped('craftingstation:crafting_station', [
-		'BCB',
-		'ADA',
-		'AEA'
-	], {
-		A: '#tfc:lumber',
-		B: '#forge:screws/any_bronze', 
-		C: '#tfc:workbenches',
-		D: '#forge:tools/saws', 
-		E: '#forge:tools/hammers' 
-	}).id('tfg:shaped/crafting_station')
-
-	event.recipes.gtceu.assembler("tfg:crafting_station")
-		.itemInputs('4x #tfc:lumber', '2x #forge:screws/any_bronze', '#tfc:workbenches')
-		.itemOutputs('craftingstation:crafting_station')
-		.duration(20)
-		.circuit(10)
-		.EUt(GTValues.VA[GTValues.LV])
 }


### PR DESCRIPTION
### What is the new behavior?
Adds recipes to the new distinct crafting stations.

### Implementation Details
- Modified Additional Placements config to blacklist crafting station slabs.
- Removed all tags and hid from EMI default crafting station blocks.
- Repurposed previously done code by @Froffy025 into `kubejs/server_scripts/tfg/natural_blocks/recipes.wood.js` to add new recipes.

### Additional Information
- Companion PR to Core's https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/428