### PR TITLE
TFC Anvil Machine Example

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.metals.js
+++ b/kubejs/server_scripts/tfc/recipes.metals.js
@@ -1,6 +1,9 @@
 ﻿// priority: 0
 "use strict";
 
+const $TFCAnvilRecipeLogic = Java.loadClass("su.terrafirmagreg.core.common.tfgt.machine.trait.TFCAnvilRecipeLogic")
+const $ForgeRule = Java.loadClass("net.dries007.tfc.common.capabilities.forge.ForgeRule")
+
 function registerTFCMetalsRecipes(event) {
 
 	//#region Alloying
@@ -351,4 +354,51 @@ function registerTFCMetalsRecipes(event) {
 		})
 	})
 	//#endregion
+
+	// #region - TFC Anvil Machine Example (Tungstensteel)
+
+	// Remove existing recipes
+	event.remove({ id: 'gtceu:electric_blast_furnace/blast_tungsten_steel' })
+	event.remove({ id: 'gtceu:electric_blast_furnace/blast_tungsten_steel_gas' })
+	event.remove({ id: 'gtceu:vacuum_freezer/cool_hot_high_carbon_tungstensteel_ingot' })
+
+	// Tungstensteel Dust -> Hot High Carbon Tungstensteel ingot
+	event.replaceInput({ id: 'gtceu:electric_blast_furnace/blast_high_carbon_tungstensteel' }, 'tfg:high_carbon_tungstensteel_dust', 'gtceu:tungsten_steel_dust')
+	event.replaceInput({ id: 'gtceu:electric_blast_furnace/blast_high_carbon_tungstensteel_gas' }, 'tfg:high_carbon_tungstensteel_dust', 'gtceu:tungsten_steel_dust')
+
+	// Hot High Carbon Tungstensteel Ingot -> Hot Tungstensteel Ingot
+	event.recipes.tfc.anvil('gtceu:hot_tungsten_steel_ingot', 'tfg:hot_high_carbon_tungstensteel_ingot', ['hit_last', 'hit_second_last', 'hit_third_last'])
+		.tier(6) // Red/Blue Steel
+		.id('tfc:anvil/hot_tungsten_steel_ingot')
+
+	// Register anvil machine recipe - TODO: Extract to a helper function
+	$TFCAnvilRecipeLogic.RegisterRecipeData(
+		'tfc:anvil/hot_tungsten_steel_ingot',
+		$SizedIngredient.create('tfg:hot_high_carbon_tungstensteel_ingot', 1),
+		0,
+		[$ForgeRule.HIT_LAST, $ForgeRule.HIT_SECOND_LAST, $ForgeRule.HIT_THIRD_LAST],
+		false,
+		TFC.isp.of('gtceu:hot_tungsten_steel_ingot').asCanonClass()
+	)
+
+	const anvilActions = [
+		'anvil_light_hit',
+		'anvil_medium_hit',
+		'anvil_hard_hit',
+		'anvil_draw',
+		'anvil_punch',
+		'anvil_bend',
+		'anvil_upset',
+		'anvil_shrink'
+	]
+
+	anvilActions.forEach((action) => {
+		event.recipes.gtceu[action]('hot_tungsten_steel_ingot')
+		.itemInputs('tfg:hot_high_carbon_tungstensteel_ingot')
+		.itemOutputs('gtceu:hot_tungsten_steel_ingot')
+		.duration(20 * 10)
+		.EUt(7)
+	})
+
+	// #endregion
 }

--- a/kubejs/startup_scripts/tfg/materials/materials.misc_alloys.js
+++ b/kubejs/startup_scripts/tfg/materials/materials.misc_alloys.js
@@ -94,4 +94,14 @@ function registerTFGMiscAlloyMaterials(event) {
             GTMaterialFlags.GENERATE_ROD,
 			GTMaterialFlags.GENERATE_LONG_ROD,
             GTMaterialFlags.DISABLE_DECOMPOSITION)
+
+	// Example Ingot - Hot High Carbon Tungstensteel
+	event.create('tfg:high_carbon_tungstensteel')
+		.ingot()
+		.color(0x717c98)
+		.secondaryColor(0x9aa4c7)
+		.iconSet('dull')
+		.blastTemp(3000, $BlastProperty.GasTier.MID, GTValues.VA[GTValues.EV], (20*50))
+		.components('1x iron', '1x tungsten')
+		.flags(GTMaterialFlags.DISABLE_DECOMPOSITION)
 }


### PR DESCRIPTION
Companion PR in core: https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/432

This PR registers recipes to make use of the electric anvil machine, currently there is one available recipe for testing: Hot High Carbon Tungstensteel Ingot -> Hot Tungstensteel Ingot.

### How it Works
Place the machine and set the mode to the anvil step you want to perform, put an ingot into the input slot and the machine will output a worked version of that ingot with the anvil step applied. Performing the last anvil step will give the output item instead. Chaining these machines together so that they auto-output into each other lets you build processing lines like this:
<img width="2560" height="1377" alt="2026-04-20_16 45 36" src="https://github.com/user-attachments/assets/7c34e950-7e6f-492b-8dc7-486ab76c7b7e" />

**This is a work in progress, do not use this in worlds that you care about.**