### PR TITLE
Add chainsaws to #tfc:axes

### DIFF
--- a/kubejs/server_scripts/tfc/tags.js
+++ b/kubejs/server_scripts/tfc/tags.js
@@ -20,6 +20,9 @@ function registerTFCItemTags(event) {
         }
     });
 
+    // Add chainsaws to #tfc:axes so they drop fruit tree saplings
+    event.add("tfc:axes", "#forge:tools/chainsaws");
+
     /**
      * @type {string[]} - Item IDs and tags usable on tfc tool racks.
      */


### PR DESCRIPTION
### Fixes
https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/3346

### Bug cause
TFC's fruit tree loot tables only check for `#tfc:axes`