### PR TITLE
fix(food): Make brioche dough craft output 5

### DIFF
--- a/kubejs/server_scripts/tfg/food/recipes.food.js
+++ b/kubejs/server_scripts/tfg/food/recipes.food.js
@@ -1678,7 +1678,7 @@ function registerTFGFoodRecipes(event) {
 			'firmalife:tirage_mixture'
 		])
 		.fluidIngredient(TFC.fluidStackIngredient('#tfc:milks', 500))
-		.outputItem('6x tfg:food/brioche_dough')
+		.outputItem('5x tfg:food/brioche_dough')
 		.id('tfg:mixing_bowl/brioche_dough');
 
 	global.processorRecipe(event, 'brioche_dough/tirage_mixture', 20*2, GTValues.VA[GTValues.ULV], {


### PR DESCRIPTION
## Summary
Recipe had 6 before, but in practice it outputted 5 (verified on local server), as mixing bowl has maximum capacity of 5 (AFAIK). Processor recipe left unchanged
I reduced the recipe to output 5 so it matches the real world. I believe it is harmless.
I did not test this change, but given it is simple kubejs update, I dont think I need to


**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
TheSprtCZ