### PR TITLE
changed cutter slab and lumber recipe and unpack lumber from planks

### DIFF
--- a/kubejs/server_scripts/tfg/natural_blocks/recipes.wood.js
+++ b/kubejs/server_scripts/tfg/natural_blocks/recipes.wood.js
@@ -83,7 +83,12 @@ function registerTFGWoodenRecipes(event) {
 			)
 				.id(`tfg:shapeless/${name}_lumber_from_plank`)
 
-			generateCutterRecipe(event, plank, `4x ${lumber}`, 50, 7, `${name}_lumber_from_plank`)
+			event.recipes.gtceu.packer(`tfg:${name}_lumber_from_plank`)
+				.itemInputs(`${plank}`)
+				.circuit(1)
+				.itemOutputs(`4x ${lumber}`)
+				.duration(50)
+				.EUt(GTValues.VA[GTValues.ULV])	
 
 			// Plank from lumber
 			event.shaped(plank, [
@@ -123,6 +128,8 @@ function registerTFGWoodenRecipes(event) {
 				A: plank
 			})
 				.id(`tfg:shaped/${name}_slab_from_plank`)
+
+			generateCutterRecipe(event, plank, `2x ${slab}`, 50, 7 , `${name}_slab_from_plank`)
 		}
 
 		// Lumber from stair


### PR DESCRIPTION
## What is the new behavior?
Alternative method to using Mechanical Crafters to automate Slabs

## Implementation Details
Removed GT Cutter Recipe Plank -> 4x Lumber
Added GT Cutter Recipe Plank -> 2x Slab
Added GT Packer Recipe Plank + Circuit 1 -> 4x Lumber

## Outcome
#3901 