### PR TITLE
feat(kubejs): Make Ender dust fertilizer

### DIFF
--- a/kubejs/server_scripts/tfc/data.js
+++ b/kubejs/server_scripts/tfc/data.js
@@ -114,6 +114,10 @@ const registerTFCFertilizers = (event) => {
 	event.fertilizer('gtceu:tiny_dark_ash_dust', null, 0.01, 0.03)
 	event.fertilizer('gtceu:small_dark_ash_dust', null, 0.025, 0.075)
 	event.fertilizer('gtceu:dark_ash_dust', null, 0.1, 0.3)
+
+	event.fertilizer('ae2:ender_dust', 0.5, null, 0.5)
+	event.fertilizer('gtceu:small_ender_pearl_dust', 0.125, null, 0.125)
+	event.fertilizer('gtceu:tiny_ender_pearl_dust', 0.055, null, 0.055)
 }
 
 


### PR DESCRIPTION
## What is the new behavior?
Makes the ender dust a fertilizer, since it contains both nitrogen and potassium

## Implementation Details
I had no idea what to choose as the value of the fertilizer as I am not sure how easily farmed these are, I consider them rare so I put 50% fertilization as a base, let me know if that makes sense

**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
TheSprtCZ