### PR TITLE
SNS Hiking Boot Changes

### DIFF
--- a/defaultconfigs/sns-server.toml
+++ b/defaultconfigs/sns-server.toml
@@ -187,7 +187,7 @@
 	["Boot config"."Blue Steel Toe Boots"]
 		#The movement speed bonus these boots provide
 		#Range: 0.0 ~ 1024.0
-		movementSpeed = 0.25
+		movementSpeed = 0.2
 		#The step height bonus these boots provide
 		#Range: 0.0 ~ 512.0
 		stepHeight = 0.5
@@ -202,10 +202,10 @@
 	["Boot config"."Red Steel Toe Boots"]
 		#The movement speed bonus these boots provide
 		#Range: 0.0 ~ 1024.0
-		movementSpeed = 0.2
+		movementSpeed = 0.25
 		#The step height bonus these boots provide
 		#Range: 0.0 ~ 512.0
-		stepHeight = 0.5
+		stepHeight = 0
 		#The extra fall distance in blocks before you begin taking fall damage
 		#Range: 0.0 ~ 64.0
 		fallPadding = 5.0

--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -250,6 +250,14 @@ const registerTooltips = (event) => {
 		text.add(2, Text.translate('tfg.tooltip.armor.space_suit_insulation'));
 		text.add(3, Text.translate('tfg.tooltip.armor.space_suit_set'));
 	})
+	event.addAdvanced(['sns:blue_steel_toe_hiking_boots'], (item, advanced, text) => {
+		text.add(1, Text.translate('tfg.tooltip.armor.blue_steel_toe_hiking_boots_warmth'));
+		text.add(2, Text.translate('tfg.tooltip.armor.blue_steel_toe_hiking_boots_insulation'));
+	})
+	event.addAdvanced(['sns:red_steel_toe_hiking_boots'], (item, advanced, text) => {
+		text.add(1, Text.translate('tfg.tooltip.armor.red_steel_toe_hiking_boots_warmth'));
+		text.add(2, Text.translate('tfg.tooltip.armor.red_steel_toe_hiking_boots_insulation'));
+	})
 
 	// Supports
 	global.TFC_WOOD_TYPES.forEach(wood => {


### PR DESCRIPTION
### What is the new behavior?
Alters the stats of Hiking Boots.

### Implementation Details
- Blue Steel Hiking Boots are now slower compared to Red Steel Hiking Boots.
- Red Steel Hiking Boots no longer have step up height.
- Added tooltips for the Ambiental stats added in Core.

### Additional Information
- Fixes #3669 
- Core Companion PR: https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/445
- Tools Companion PR: https://github.com/TerraFirmaGreg-Team/Tools-Modern/pull/467