### PR TITLE
Fix sequenced train track recipes and hide in EMI

### DIFF
--- a/kubejs/client_scripts/emixx.js
+++ b/kubejs/client_scripts/emixx.js
@@ -229,7 +229,6 @@ const registerSingleGroups = (event) => {
 
         // Steam n Rails
         '#railways:conductor_caps',
-		'#tfg:incomplete_tracks',
 		'#tfg:locometal_blocks',
         '#tfg:smokestacks',
         '#tfg:train_connectors',

--- a/kubejs/server_scripts/railways/recipes.js
+++ b/kubejs/server_scripts/railways/recipes.js
@@ -535,6 +535,67 @@ const registerRailWaysRecipes = (event) => {
 		.duration(250)
 		.EUt(32)
 
+	// Create Stone Tracks (Normal)
+	const stoneTrackSlabs = Ingredient.of('#tfg:rock_slabs').subtract('minecraft:blackstone_slab')
+
+	event.recipes.createSequencedAssembly([
+		'32x create:track',
+	], stoneTrackSlabs, [
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', stoneTrackSlabs]),
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:track_rods']),
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfc:mortar']),
+		event.recipes.greate.pressing('railways:track_incomplete_blackstone', 'railways:track_incomplete_blackstone'),
+	]).transitionalItem('create:incomplete_track').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite')
+
+	event.recipes.gtceu.assembler('railways/track')
+		.itemInputs(stoneTrackSlabs.withCount(3), '2x #tfg:track_rods')
+		.inputFluids(Fluid.of('gtceu:concrete', 144))
+		.itemOutputs('16x create:track')
+		.duration(800)
+		.EUt(16)
+		.circuit(2)
+
+	// Create Stone Tracks (Narrow)
+	event.recipes.createSequencedAssembly([
+		'32x railways:track_create_andesite_narrow',
+	], stoneTrackSlabs, [
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfg:track_rods']),
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfc:mortar']),
+		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_narrow', 'railways:track_incomplete_create_andesite_narrow'),
+	]).transitionalItem('railways:track_incomplete_create_andesite_narrow').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_narrow')
+
+	event.recipes.gtceu.assembler('railways/track_create_andesite_narrow')
+		.itemInputs(stoneTrackSlabs, '2x #tfg:track_rods')
+		.inputFluids(Fluid.of('gtceu:concrete', 144))
+		.itemOutputs('16x railways:track_create_andesite_narrow')
+		.duration(800)
+		.EUt(16)
+		.circuit(1)
+
+	// Create Stone Tracks (Wide)
+	event.recipes.createSequencedAssembly([
+		'32x railways:track_create_andesite_wide',
+	], stoneTrackSlabs, [
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', Ingredient.of('#forge:stone').subtract('minecraft:blackstone')]),
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfg:track_rods']),
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfc:mortar']),
+		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_wide', 'railways:track_incomplete_create_andesite_wide'),
+	]).transitionalItem('railways:track_incomplete_create_andesite_wide').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_wide')
+
+	event.recipes.gtceu.assembler('railways/track_create_andesite_wide')
+		.itemInputs(stoneTrackSlabs.withCount(5), '2x #tfg:track_rods')
+		.inputFluids(Fluid.of('gtceu:concrete', 144))
+		.itemOutputs('16x railways:track_create_andesite_wide')
+		.duration(800)
+		.EUt(16)
+		.circuit(3)
+
+	event.recipes.gtceu.assembler('tfg:railways/phantom_tracks')
+		.itemInputs('32x #create:tracks', '#forge:small_dusts/ender_pearl')
+		.itemOutputs('32x railways:track_phantom')
+		.duration(100)
+		.EUt(16)
+
 	// TFC Wood Tracks
 	global.TFC_WOOD_TYPES.forEach(woodType => {
 		// Normal
@@ -656,65 +717,6 @@ const registerRailWaysRecipes = (event) => {
 			.EUt(16)
 			.circuit(3)
 	})
-
-	// Create Stone Tracks (Normal)
-	event.recipes.createSequencedAssembly([
-		'32x create:track',
-	], '#tfg:rock_slabs', [
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:rock_slabs']),
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:track_rods']),
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfc:mortar']),
-		event.recipes.greate.pressing('railways:track_incomplete_blackstone', 'railways:track_incomplete_blackstone'),
-	]).transitionalItem('create:incomplete_track').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite')
-
-	event.recipes.gtceu.assembler('railways/track')
-		.itemInputs('3x #tfg:rock_slabs', '2x #tfg:track_rods')
-		.inputFluids(Fluid.of('gtceu:concrete', 144))
-		.itemOutputs('16x create:track')
-		.duration(800)
-		.EUt(16)
-		.circuit(2)
-
-	// Create Stone Tracks (Narrow)
-	event.recipes.createSequencedAssembly([
-		'32x railways:track_create_andesite_narrow',
-	], '#tfg:rock_slabs', [
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfg:track_rods']),
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfc:mortar']),
-		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_narrow', 'railways:track_incomplete_create_andesite_narrow'),
-	]).transitionalItem('railways:track_incomplete_create_andesite_narrow').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_narrow')
-
-	event.recipes.gtceu.assembler('railways/track_create_andesite_narrow')
-		.itemInputs('#tfg:rock_slabs', '2x #tfg:track_rods')
-		.inputFluids(Fluid.of('gtceu:concrete', 144))
-		.itemOutputs('16x railways:track_create_andesite_narrow')
-		.duration(800)
-		.EUt(16)
-		.circuit(1)
-
-	// Create Stone Tracks (Wide)
-	event.recipes.createSequencedAssembly([
-		'32x railways:track_create_andesite_wide',
-	], '#tfg:rock_slabs', [
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#forge:stone']),
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfg:track_rods']),
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfc:mortar']),
-		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_wide', 'railways:track_incomplete_create_andesite_wide'),
-	]).transitionalItem('railways:track_incomplete_create_andesite_wide').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_wide')
-
-	event.recipes.gtceu.assembler('railways/track_create_andesite_wide')
-		.itemInputs('5x #tfg:rock_slabs', '2x #tfg:track_rods')
-		.inputFluids(Fluid.of('gtceu:concrete', 144))
-		.itemOutputs('16x railways:track_create_andesite_wide')
-		.duration(800)
-		.EUt(16)
-		.circuit(3)
-
-	event.recipes.gtceu.assembler('tfg:railways/phantom_tracks')
-		.itemInputs('32x #create:tracks', '#forge:small_dusts/ender_pearl')
-		.itemOutputs('32x railways:track_phantom')
-		.duration(100)
-		.EUt(16)
 
 	event.shapeless('8x railways:track_phantom', ['#forge:tiny_dusts/ender_pearl', '8x #create:tracks'])
 		.id('tfg:shapeless/phantom_tracks')

--- a/kubejs/server_scripts/railways/recipes.js
+++ b/kubejs/server_scripts/railways/recipes.js
@@ -504,7 +504,7 @@ const registerRailWaysRecipes = (event) => {
 
 	//#region Tracks
 
-	// Монорельс
+	// Monorails
 	event.recipes.createSequencedAssembly([
 		'32x railways:track_monorail',
 	], 'create:metal_girder', [
@@ -535,7 +535,42 @@ const registerRailWaysRecipes = (event) => {
 		.duration(250)
 		.EUt(32)
 
-	// Железнодорожное полотно (Узкое)
+	// Create Stone Tracks (Normal)
+	event.recipes.createSequencedAssembly([
+		'16x create:track',
+	], '#tfg:rock_slabs', [
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:rock_slabs']),
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#forge:rods/wrought_iron']),
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfc:mortar']),
+		event.recipes.greate.pressing('railways:track_incomplete_blackstone', 'railways:track_incomplete_blackstone'),
+	]).transitionalItem('create:incomplete_track').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite/wrought_iron')
+
+	event.recipes.gtceu.assembler('railways/track/wrought_iron')
+		.itemInputs('3x #tfg:rock_slabs', '2x #forge:rods/wrought_iron')
+		.inputFluids(Fluid.of('gtceu:concrete', 144))
+		.itemOutputs('16x create:track')
+		.duration(800)
+		.EUt(16)
+		.circuit(2)
+
+	event.recipes.createSequencedAssembly([
+		'32x create:track',
+	], '#tfg:rock_slabs', [
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:rock_slabs']),
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#forge:rods/steel']),
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfc:mortar']),
+		event.recipes.greate.pressing('railways:track_incomplete_blackstone', 'railways:track_incomplete_blackstone'),
+	]).transitionalItem('tfg:track_incomplete_create_andesite_steel').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite/steel')
+
+	event.recipes.gtceu.assembler('railways/track/steel')
+		.itemInputs('3x #tfg:rock_slabs', '2x #forge:rods/steel')
+		.inputFluids(Fluid.of('gtceu:concrete', 144))
+		.itemOutputs('32x create:track')
+		.duration(800)
+		.EUt(16)
+		.circuit(2)
+
+	// Create Stone Tracks (Narrow)
 	event.recipes.createSequencedAssembly([
 		'16x railways:track_create_andesite_narrow',
 	], '#tfg:rock_slabs', [
@@ -558,7 +593,7 @@ const registerRailWaysRecipes = (event) => {
 		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#forge:rods/steel']),
 		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfc:mortar']),
 		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_narrow', 'railways:track_incomplete_create_andesite_narrow'),
-	]).transitionalItem('railways:track_incomplete_create_andesite_narrow').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_narrow/steel')
+	]).transitionalItem('tfg:track_incomplete_create_andesite_narrow_steel').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_narrow/steel')
 
 	event.recipes.gtceu.assembler('railways/track_create_andesite_narrow/steel')
 		.itemInputs('#tfg:rock_slabs', '2x #forge:rods/steel')
@@ -568,42 +603,7 @@ const registerRailWaysRecipes = (event) => {
 		.EUt(16)
 		.circuit(1)
 
-	// Железнодорожное полотно (Нормальное)
-	event.recipes.createSequencedAssembly([
-		'16x create:track',
-	], '#tfg:rock_slabs', [
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:rock_slabs']),
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#forge:rods/wrought_iron']),
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfc:mortar']),
-		event.recipes.greate.pressing('railways:track_incomplete_blackstone', 'railways:track_incomplete_blackstone'),
-	]).transitionalItem('railways:track_incomplete_blackstone').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite/wrought_iron')
-
-	event.recipes.gtceu.assembler('railways/track/wrought_iron')
-		.itemInputs('3x #tfg:rock_slabs', '2x #forge:rods/wrought_iron')
-		.inputFluids(Fluid.of('gtceu:concrete', 144))
-		.itemOutputs('16x create:track')
-		.duration(800)
-		.EUt(16)
-		.circuit(2)
-
-	event.recipes.createSequencedAssembly([
-		'32x create:track',
-	], '#tfg:rock_slabs', [
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:rock_slabs']),
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#forge:rods/steel']),
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfc:mortar']),
-		event.recipes.greate.pressing('railways:track_incomplete_blackstone', 'railways:track_incomplete_blackstone'),
-	]).transitionalItem('railways:track_incomplete_blackstone').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite/steel')
-
-	event.recipes.gtceu.assembler('railways/track/steel')
-		.itemInputs('3x #tfg:rock_slabs', '2x #forge:rods/steel')
-		.inputFluids(Fluid.of('gtceu:concrete', 144))
-		.itemOutputs('32x create:track')
-		.duration(800)
-		.EUt(16)
-		.circuit(2)
-
-	// Железнодорожное полотно (Широкое)
+	// Create Stone Tracks (Wide)
 	event.recipes.createSequencedAssembly([
 		'16x railways:track_create_andesite_wide',
 	], '#tfg:rock_slabs', [
@@ -628,7 +628,7 @@ const registerRailWaysRecipes = (event) => {
 		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#forge:rods/steel']),
 		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfc:mortar']),
 		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_wide', 'railways:track_incomplete_create_andesite_wide'),
-	]).transitionalItem('railways:track_incomplete_create_andesite_wide').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_wide/steel')
+	]).transitionalItem('tfg:track_incomplete_create_andesite_wide_steel').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_wide/steel')
 
 	event.recipes.gtceu.assembler('railways/track_create_andesite_wide/steel')
 		.itemInputs('5x #tfg:rock_slabs', '2x #forge:rods/steel')
@@ -638,42 +638,9 @@ const registerRailWaysRecipes = (event) => {
 		.EUt(16)
 		.circuit(3)
 
-	// Железнодородные полотна из дерева
+	// TFC Wood Tracks
 	global.TFC_WOOD_TYPES.forEach(woodType => {
-		// Узкое
-		event.recipes.createSequencedAssembly([
-			`16x railways:track_tfc_${woodType}_narrow`,
-		], `tfc:wood/planks/${woodType}_slab`, [
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#forge:rods/wrought_iron']),
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#tfc:mortar']),
-			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}_narrow`, `railways:track_incomplete_tfc_${woodType}_narrow`),
-		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_narrow/wrought_iron`)
-
-		event.recipes.gtceu.assembler(`railways/track_create_${woodType}_narrow/wrought_iron`)
-			.itemInputs(`tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/wrought_iron')
-			.inputFluids(Fluid.of('gtceu:concrete', 144))
-			.itemOutputs(`16x railways:track_tfc_${woodType}_narrow`)
-			.duration(800)
-			.EUt(16)
-			.circuit(1)
-
-		event.recipes.createSequencedAssembly([
-			`32x railways:track_tfc_${woodType}_narrow`,
-		], `tfc:wood/planks/${woodType}_slab`, [
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#forge:rods/steel']),
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#tfc:mortar']),
-			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}_narrow`, `railways:track_incomplete_tfc_${woodType}_narrow`),
-		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_narrow/steel`)
-
-		event.recipes.gtceu.assembler(`railways/track_create_${woodType}_narrow/steel`)
-			.itemInputs(`tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/steel')
-			.inputFluids(Fluid.of('gtceu:concrete', 144))
-			.itemOutputs(`32x railways:track_tfc_${woodType}_narrow`)
-			.duration(800)
-			.EUt(16)
-			.circuit(1)
-
-		// Нормальное
+		// Normal
 		event.recipes.createSequencedAssembly([
 			`16x railways:track_tfc_${woodType}`,
 		], `tfc:wood/planks/${woodType}_slab`, [
@@ -698,7 +665,7 @@ const registerRailWaysRecipes = (event) => {
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, '#forge:rods/steel']),
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, '#tfc:mortar']),
 			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}`, `railways:track_incomplete_tfc_${woodType}`),
-		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}/steel`)
+		]).transitionalItem(`tfg:track_incomplete_tfc_${woodType}_steel`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}/steel`)
 
 		event.recipes.gtceu.assembler(`railways/track_${woodType}/steel`)
 			.itemInputs(`3x tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/steel')
@@ -708,7 +675,40 @@ const registerRailWaysRecipes = (event) => {
 			.EUt(16)
 			.circuit(2)
 
-		// Широкое
+		// Narrow
+		event.recipes.createSequencedAssembly([
+			`16x railways:track_tfc_${woodType}_narrow`,
+		], `tfc:wood/planks/${woodType}_slab`, [
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#forge:rods/wrought_iron']),
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#tfc:mortar']),
+			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}_narrow`, `railways:track_incomplete_tfc_${woodType}_narrow`),
+		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_narrow/wrought_iron`)
+
+		event.recipes.gtceu.assembler(`railways/track_create_${woodType}_narrow/wrought_iron`)
+			.itemInputs(`tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/wrought_iron')
+			.inputFluids(Fluid.of('gtceu:concrete', 144))
+			.itemOutputs(`16x railways:track_tfc_${woodType}_narrow`)
+			.duration(800)
+			.EUt(16)
+			.circuit(1)
+
+		event.recipes.createSequencedAssembly([
+			`32x railways:track_tfc_${woodType}_narrow`,
+		], `tfc:wood/planks/${woodType}_slab`, [
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#forge:rods/steel']),
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#tfc:mortar']),
+			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}_narrow`, `railways:track_incomplete_tfc_${woodType}_narrow`),
+		]).transitionalItem(`tfg:track_incomplete_tfc_${woodType}_narrow_steel`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_narrow/steel`)
+
+		event.recipes.gtceu.assembler(`railways/track_create_${woodType}_narrow/steel`)
+			.itemInputs(`tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/steel')
+			.inputFluids(Fluid.of('gtceu:concrete', 144))
+			.itemOutputs(`32x railways:track_tfc_${woodType}_narrow`)
+			.duration(800)
+			.EUt(16)
+			.circuit(1)
+
+		// Wide
 		event.recipes.createSequencedAssembly([
 			`16x railways:track_tfc_${woodType}_wide`,
 		], `tfc:wood/planks/${woodType}_slab`, [
@@ -733,7 +733,7 @@ const registerRailWaysRecipes = (event) => {
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, `#forge:rods/steel`]),
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, '#tfc:mortar']),
 			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}_wide`, `railways:track_incomplete_tfc_${woodType}_wide`)
-		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_wide`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_wide/steel`)
+		]).transitionalItem(`tfg:track_incomplete_tfc_${woodType}_wide_steel`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_wide/steel`)
 
 		event.recipes.gtceu.assembler(`railways/track_${woodType}_wide/steel`)
 			.itemInputs(`5x tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/steel')
@@ -781,7 +781,7 @@ const registerRailWaysRecipes = (event) => {
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_narrow`, [`railways:track_incomplete_${x.rail}_narrow`, `#forge:rods/steel`]),
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_narrow`, [`railways:track_incomplete_${x.rail}_narrow`, `#tfc:mortar`]),
 			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}_narrow`, `railways:track_incomplete_${x.rail}_narrow`),
-		]).transitionalItem(`railways:track_incomplete_${x.rail}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_narrow_alt/steel`)
+		]).transitionalItem(`tfg:track_incomplete_${x.rail}_narrow_steel`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_narrow_alt/steel`)
 
 		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_narrow_alt/steel`)
 			.itemInputs(x.slab, `2x #forge:rods/steel`)
@@ -815,7 +815,7 @@ const registerRailWaysRecipes = (event) => {
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, `#forge:rods/steel`]),
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, `#tfc:mortar`]),
 			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}`, `railways:track_incomplete_${x.rail}`),
-		]).transitionalItem(`railways:track_incomplete_${x.rail}`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_alt/steel`)
+		]).transitionalItem(`tfg:track_incomplete_${x.rail}_steel`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_alt/steel`)
 
 		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_normal_alt/steel`)
 			.itemInputs(`3x ${x.slab}`, `2x #forge:rods/steel`)
@@ -849,7 +849,7 @@ const registerRailWaysRecipes = (event) => {
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, `#forge:rods/steel`]),
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, `#tfc:mortar`]),
 			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}_wide`, `railways:track_incomplete_${x.rail}_wide`),
-		]).transitionalItem(`railways:track_incomplete_${x.rail}_wide`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_wide_alt/steel`)
+		]).transitionalItem(`tfg:track_incomplete_${x.rail}_wide_steel`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_wide_alt/steel`)
 
 		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_wide_alt/steel`)
 			.itemInputs(`5x ${x.slab}`, `2x #forge:rods/steel`)

--- a/kubejs/server_scripts/railways/recipes.js
+++ b/kubejs/server_scripts/railways/recipes.js
@@ -535,59 +535,6 @@ const registerRailWaysRecipes = (event) => {
 		.duration(250)
 		.EUt(32)
 
-	// Create Stone Tracks (Normal)
-	event.recipes.createSequencedAssembly([
-		'32x create:track',
-	], '#tfg:rock_slabs', [
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:rock_slabs']),
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:track_rods']),
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfc:mortar']),
-		event.recipes.greate.pressing('railways:track_incomplete_blackstone', 'railways:track_incomplete_blackstone'),
-	]).transitionalItem('create:incomplete_track').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite')
-
-	event.recipes.gtceu.assembler('railways/track')
-		.itemInputs('3x #tfg:rock_slabs', '2x #tfg:track_rods')
-		.inputFluids(Fluid.of('gtceu:concrete', 144))
-		.itemOutputs('16x create:track')
-		.duration(800)
-		.EUt(16)
-		.circuit(2)
-
-	// Create Stone Tracks (Narrow)
-	event.recipes.createSequencedAssembly([
-		'32x railways:track_create_andesite_narrow',
-	], '#tfg:rock_slabs', [
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfg:track_rods']),
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfc:mortar']),
-		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_narrow', 'railways:track_incomplete_create_andesite_narrow'),
-	]).transitionalItem('railways:track_incomplete_create_andesite_narrow').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_narrow')
-
-	event.recipes.gtceu.assembler('railways/track_create_andesite_narrow')
-		.itemInputs('#tfg:rock_slabs', '2x #tfg:track_rods')
-		.inputFluids(Fluid.of('gtceu:concrete', 144))
-		.itemOutputs('16x railways:track_create_andesite_narrow')
-		.duration(800)
-		.EUt(16)
-		.circuit(1)
-
-	// Create Stone Tracks (Wide)
-	event.recipes.createSequencedAssembly([
-		'32x railways:track_create_andesite_wide',
-	], '#tfg:rock_slabs', [
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#forge:stone']),
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfg:track_rods']),
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfc:mortar']),
-		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_wide', 'railways:track_incomplete_create_andesite_wide'),
-	]).transitionalItem('railways:track_incomplete_create_andesite_wide').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_wide')
-
-	event.recipes.gtceu.assembler('railways/track_create_andesite_wide')
-		.itemInputs('5x #tfg:rock_slabs', '2x #tfg:track_rods')
-		.inputFluids(Fluid.of('gtceu:concrete', 144))
-		.itemOutputs('16x railways:track_create_andesite_wide')
-		.duration(800)
-		.EUt(16)
-		.circuit(3)
-
 	// TFC Wood Tracks
 	global.TFC_WOOD_TYPES.forEach(woodType => {
 		// Normal
@@ -709,6 +656,59 @@ const registerRailWaysRecipes = (event) => {
 			.EUt(16)
 			.circuit(3)
 	})
+
+	// Create Stone Tracks (Normal)
+	event.recipes.createSequencedAssembly([
+		'32x create:track',
+	], '#tfg:rock_slabs', [
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:rock_slabs']),
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:track_rods']),
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfc:mortar']),
+		event.recipes.greate.pressing('railways:track_incomplete_blackstone', 'railways:track_incomplete_blackstone'),
+	]).transitionalItem('create:incomplete_track').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite')
+
+	event.recipes.gtceu.assembler('railways/track')
+		.itemInputs('3x #tfg:rock_slabs', '2x #tfg:track_rods')
+		.inputFluids(Fluid.of('gtceu:concrete', 144))
+		.itemOutputs('16x create:track')
+		.duration(800)
+		.EUt(16)
+		.circuit(2)
+
+	// Create Stone Tracks (Narrow)
+	event.recipes.createSequencedAssembly([
+		'32x railways:track_create_andesite_narrow',
+	], '#tfg:rock_slabs', [
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfg:track_rods']),
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfc:mortar']),
+		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_narrow', 'railways:track_incomplete_create_andesite_narrow'),
+	]).transitionalItem('railways:track_incomplete_create_andesite_narrow').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_narrow')
+
+	event.recipes.gtceu.assembler('railways/track_create_andesite_narrow')
+		.itemInputs('#tfg:rock_slabs', '2x #tfg:track_rods')
+		.inputFluids(Fluid.of('gtceu:concrete', 144))
+		.itemOutputs('16x railways:track_create_andesite_narrow')
+		.duration(800)
+		.EUt(16)
+		.circuit(1)
+
+	// Create Stone Tracks (Wide)
+	event.recipes.createSequencedAssembly([
+		'32x railways:track_create_andesite_wide',
+	], '#tfg:rock_slabs', [
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#forge:stone']),
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfg:track_rods']),
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfc:mortar']),
+		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_wide', 'railways:track_incomplete_create_andesite_wide'),
+	]).transitionalItem('railways:track_incomplete_create_andesite_wide').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_wide')
+
+	event.recipes.gtceu.assembler('railways/track_create_andesite_wide')
+		.itemInputs('5x #tfg:rock_slabs', '2x #tfg:track_rods')
+		.inputFluids(Fluid.of('gtceu:concrete', 144))
+		.itemOutputs('16x railways:track_create_andesite_wide')
+		.duration(800)
+		.EUt(16)
+		.circuit(3)
 
 	event.recipes.gtceu.assembler('tfg:railways/phantom_tracks')
 		.itemInputs('32x #create:tracks', '#forge:small_dusts/ender_pearl')

--- a/kubejs/server_scripts/railways/recipes.js
+++ b/kubejs/server_scripts/railways/recipes.js
@@ -537,103 +537,53 @@ const registerRailWaysRecipes = (event) => {
 
 	// Create Stone Tracks (Normal)
 	event.recipes.createSequencedAssembly([
-		'16x create:track',
+		'32x create:track',
 	], '#tfg:rock_slabs', [
 		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:rock_slabs']),
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#forge:rods/wrought_iron']),
+		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:track_rods']),
 		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfc:mortar']),
 		event.recipes.greate.pressing('railways:track_incomplete_blackstone', 'railways:track_incomplete_blackstone'),
-	]).transitionalItem('create:incomplete_track').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite/wrought_iron')
+	]).transitionalItem('create:incomplete_track').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite')
 
-	event.recipes.gtceu.assembler('railways/track/wrought_iron')
-		.itemInputs('3x #tfg:rock_slabs', '2x #forge:rods/wrought_iron')
+	event.recipes.gtceu.assembler('railways/track')
+		.itemInputs('3x #tfg:rock_slabs', '2x #tfg:track_rods')
 		.inputFluids(Fluid.of('gtceu:concrete', 144))
 		.itemOutputs('16x create:track')
 		.duration(800)
 		.EUt(16)
 		.circuit(2)
 
-	event.recipes.createSequencedAssembly([
-		'32x create:track',
-	], '#tfg:rock_slabs', [
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfg:rock_slabs']),
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#forge:rods/steel']),
-		event.recipes.createDeploying('railways:track_incomplete_blackstone', ['railways:track_incomplete_blackstone', '#tfc:mortar']),
-		event.recipes.greate.pressing('railways:track_incomplete_blackstone', 'railways:track_incomplete_blackstone'),
-	]).transitionalItem('tfg:track_incomplete_create_andesite_steel').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite/steel')
-
-	event.recipes.gtceu.assembler('railways/track/steel')
-		.itemInputs('3x #tfg:rock_slabs', '2x #forge:rods/steel')
-		.inputFluids(Fluid.of('gtceu:concrete', 144))
-		.itemOutputs('32x create:track')
-		.duration(800)
-		.EUt(16)
-		.circuit(2)
-
 	// Create Stone Tracks (Narrow)
 	event.recipes.createSequencedAssembly([
-		'16x railways:track_create_andesite_narrow',
+		'32x railways:track_create_andesite_narrow',
 	], '#tfg:rock_slabs', [
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#forge:rods/wrought_iron']),
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfg:track_rods']),
 		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfc:mortar']),
 		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_narrow', 'railways:track_incomplete_create_andesite_narrow'),
-	]).transitionalItem('railways:track_incomplete_create_andesite_narrow').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_narrow/wrought_iron')
+	]).transitionalItem('railways:track_incomplete_create_andesite_narrow').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_narrow')
 
-	event.recipes.gtceu.assembler('railways/track_create_andesite_narrow/wrought_iron')
-		.itemInputs('#tfg:rock_slabs', '2x gtceu:steel_rod')
+	event.recipes.gtceu.assembler('railways/track_create_andesite_narrow')
+		.itemInputs('#tfg:rock_slabs', '2x #tfg:track_rods')
 		.inputFluids(Fluid.of('gtceu:concrete', 144))
 		.itemOutputs('16x railways:track_create_andesite_narrow')
 		.duration(800)
 		.EUt(16)
 		.circuit(1)
 
-	event.recipes.createSequencedAssembly([
-		'32x railways:track_create_andesite_narrow',
-	], '#tfg:rock_slabs', [
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#forge:rods/steel']),
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_narrow', ['railways:track_incomplete_create_andesite_narrow', '#tfc:mortar']),
-		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_narrow', 'railways:track_incomplete_create_andesite_narrow'),
-	]).transitionalItem('tfg:track_incomplete_create_andesite_narrow_steel').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_narrow/steel')
-
-	event.recipes.gtceu.assembler('railways/track_create_andesite_narrow/steel')
-		.itemInputs('#tfg:rock_slabs', '2x #forge:rods/steel')
-		.inputFluids(Fluid.of('gtceu:concrete', 144))
-		.itemOutputs('32x railways:track_create_andesite_narrow')
-		.duration(800)
-		.EUt(16)
-		.circuit(1)
-
 	// Create Stone Tracks (Wide)
-	event.recipes.createSequencedAssembly([
-		'16x railways:track_create_andesite_wide',
-	], '#tfg:rock_slabs', [
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#forge:stone']),
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#forge:rods/wrought_iron']),
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfc:mortar']),
-		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_wide', 'railways:track_incomplete_create_andesite_wide'),
-	]).transitionalItem('railways:track_incomplete_create_andesite_wide').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_wide/wrought_iron')
-
-	event.recipes.gtceu.assembler('railways/track_create_andesite_wide/wrought_iron')
-		.itemInputs('5x #tfg:rock_slabs', '2x #forge:rods/wrought_iron')
-		.inputFluids(Fluid.of('gtceu:concrete', 144))
-		.itemOutputs('16x railways:track_create_andesite_wide')
-		.duration(800)
-		.EUt(16)
-		.circuit(3)
-
 	event.recipes.createSequencedAssembly([
 		'32x railways:track_create_andesite_wide',
 	], '#tfg:rock_slabs', [
 		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#forge:stone']),
-		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#forge:rods/steel']),
+		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfg:track_rods']),
 		event.recipes.createDeploying('railways:track_incomplete_create_andesite_wide', ['railways:track_incomplete_create_andesite_wide', '#tfc:mortar']),
 		event.recipes.greate.pressing('railways:track_incomplete_create_andesite_wide', 'railways:track_incomplete_create_andesite_wide'),
-	]).transitionalItem('tfg:track_incomplete_create_andesite_wide_steel').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_wide/steel')
+	]).transitionalItem('railways:track_incomplete_create_andesite_wide').loops(2).id('tfg:railways/sequenced_assembly/track_create_andesite_wide')
 
-	event.recipes.gtceu.assembler('railways/track_create_andesite_wide/steel')
-		.itemInputs('5x #tfg:rock_slabs', '2x #forge:rods/steel')
+	event.recipes.gtceu.assembler('railways/track_create_andesite_wide')
+		.itemInputs('5x #tfg:rock_slabs', '2x #tfg:track_rods')
 		.inputFluids(Fluid.of('gtceu:concrete', 144))
-		.itemOutputs('32x railways:track_create_andesite_wide')
+		.itemOutputs('16x railways:track_create_andesite_wide')
 		.duration(800)
 		.EUt(16)
 		.circuit(3)
@@ -642,103 +592,53 @@ const registerRailWaysRecipes = (event) => {
 	global.TFC_WOOD_TYPES.forEach(woodType => {
 		// Normal
 		event.recipes.createSequencedAssembly([
-			`16x railways:track_tfc_${woodType}`,
+			`32x railways:track_tfc_${woodType}`,
 		], `tfc:wood/planks/${woodType}_slab`, [
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, `tfc:wood/planks/${woodType}_slab`]),
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, '#forge:rods/wrought_iron']),
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, '#tfg:track_rods']),
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, '#tfc:mortar']),
 			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}`, `railways:track_incomplete_tfc_${woodType}`),
-		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}/wrought_iron`)
+		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}`)
 
-		event.recipes.gtceu.assembler(`railways/track_${woodType}/wrought_iron`)
-			.itemInputs(`3x tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/wrought_iron')
+		event.recipes.gtceu.assembler(`railways/track_${woodType}`)
+			.itemInputs(`3x tfc:wood/planks/${woodType}_slab`, '2x #tfg:track_rods')
 			.inputFluids(Fluid.of('gtceu:concrete', 144))
 			.itemOutputs(`16x railways:track_tfc_${woodType}`)
 			.duration(800)
 			.EUt(16)
 			.circuit(2)
 
-		event.recipes.createSequencedAssembly([
-			`32x railways:track_tfc_${woodType}`,
-		], `tfc:wood/planks/${woodType}_slab`, [
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, `tfc:wood/planks/${woodType}_slab`]),
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, '#forge:rods/steel']),
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}`, [`railways:track_incomplete_tfc_${woodType}`, '#tfc:mortar']),
-			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}`, `railways:track_incomplete_tfc_${woodType}`),
-		]).transitionalItem(`tfg:track_incomplete_tfc_${woodType}_steel`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}/steel`)
-
-		event.recipes.gtceu.assembler(`railways/track_${woodType}/steel`)
-			.itemInputs(`3x tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/steel')
-			.inputFluids(Fluid.of('gtceu:concrete', 144))
-			.itemOutputs(`32x railways:track_tfc_${woodType}`)
-			.duration(800)
-			.EUt(16)
-			.circuit(2)
-
 		// Narrow
 		event.recipes.createSequencedAssembly([
-			`16x railways:track_tfc_${woodType}_narrow`,
+			`32x railways:track_tfc_${woodType}_narrow`,
 		], `tfc:wood/planks/${woodType}_slab`, [
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#forge:rods/wrought_iron']),
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#tfg:track_rods']),
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#tfc:mortar']),
 			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}_narrow`, `railways:track_incomplete_tfc_${woodType}_narrow`),
-		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_narrow/wrought_iron`)
+		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_narrow`)
 
-		event.recipes.gtceu.assembler(`railways/track_create_${woodType}_narrow/wrought_iron`)
-			.itemInputs(`tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/wrought_iron')
+		event.recipes.gtceu.assembler(`railways/track_create_${woodType}_narrow`)
+			.itemInputs(`tfc:wood/planks/${woodType}_slab`, '2x #tfg:track_rods')
 			.inputFluids(Fluid.of('gtceu:concrete', 144))
 			.itemOutputs(`16x railways:track_tfc_${woodType}_narrow`)
 			.duration(800)
 			.EUt(16)
 			.circuit(1)
 
-		event.recipes.createSequencedAssembly([
-			`32x railways:track_tfc_${woodType}_narrow`,
-		], `tfc:wood/planks/${woodType}_slab`, [
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#forge:rods/steel']),
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_narrow`, [`railways:track_incomplete_tfc_${woodType}_narrow`, '#tfc:mortar']),
-			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}_narrow`, `railways:track_incomplete_tfc_${woodType}_narrow`),
-		]).transitionalItem(`tfg:track_incomplete_tfc_${woodType}_narrow_steel`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_narrow/steel`)
-
-		event.recipes.gtceu.assembler(`railways/track_create_${woodType}_narrow/steel`)
-			.itemInputs(`tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/steel')
-			.inputFluids(Fluid.of('gtceu:concrete', 144))
-			.itemOutputs(`32x railways:track_tfc_${woodType}_narrow`)
-			.duration(800)
-			.EUt(16)
-			.circuit(1)
-
 		// Wide
-		event.recipes.createSequencedAssembly([
-			`16x railways:track_tfc_${woodType}_wide`,
-		], `tfc:wood/planks/${woodType}_slab`, [
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, `tfc:wood/planks/${woodType}`]),
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, `#forge:rods/wrought_iron`]),
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, '#tfc:mortar']),
-			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}_wide`, `railways:track_incomplete_tfc_${woodType}_wide`)
-		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_wide`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_wide/wrought_iron`)
-
-		event.recipes.gtceu.assembler(`railways/track_${woodType}_wide/wrought_iron`)
-			.itemInputs(`5x tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/wrought_iron')
-			.inputFluids(Fluid.of('gtceu:concrete', 144))
-			.itemOutputs(`16x railways:track_tfc_${woodType}_wide`)
-			.duration(800)
-			.EUt(16)
-			.circuit(3)
-
 		event.recipes.createSequencedAssembly([
 			`32x railways:track_tfc_${woodType}_wide`,
 		], `tfc:wood/planks/${woodType}_slab`, [
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, `tfc:wood/planks/${woodType}`]),
-			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, `#forge:rods/steel`]),
+			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, `#tfg:track_rods`]),
 			event.recipes.createDeploying(`railways:track_incomplete_tfc_${woodType}_wide`, [`railways:track_incomplete_tfc_${woodType}_wide`, '#tfc:mortar']),
 			event.recipes.greate.pressing(`railways:track_incomplete_tfc_${woodType}_wide`, `railways:track_incomplete_tfc_${woodType}_wide`)
-		]).transitionalItem(`tfg:track_incomplete_tfc_${woodType}_wide_steel`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_wide/steel`)
+		]).transitionalItem(`railways:track_incomplete_tfc_${woodType}_wide`).loops(2).id(`tfg:railways/sequenced_assembly/track_create_${woodType}_wide`)
 
-		event.recipes.gtceu.assembler(`railways/track_${woodType}_wide/steel`)
-			.itemInputs(`5x tfc:wood/planks/${woodType}_slab`, '2x #forge:rods/steel')
+		event.recipes.gtceu.assembler(`railways/track_${woodType}_wide`)
+			.itemInputs(`5x tfc:wood/planks/${woodType}_slab`, '2x #tfg:track_rods')
 			.inputFluids(Fluid.of('gtceu:concrete', 144))
-			.itemOutputs(`32x railways:track_tfc_${woodType}_wide`)
+			.itemOutputs(`16x railways:track_tfc_${woodType}_wide`)
 			.duration(800)
 			.EUt(16)
 			.circuit(3)
@@ -760,15 +660,15 @@ const registerRailWaysRecipes = (event) => {
 
 	OTHER_TRACKS.forEach(x => {
 		event.recipes.createSequencedAssembly([
-			`16x railways:track_${x.rail}_narrow`,
+			`32x railways:track_${x.rail}_narrow`,
 		], x.slab, [
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_narrow`, [`railways:track_incomplete_${x.rail}_narrow`, `#forge:rods/wrought_iron`]),
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_narrow`, [`railways:track_incomplete_${x.rail}_narrow`, `#tfg:track_rods`]),
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_narrow`, [`railways:track_incomplete_${x.rail}_narrow`, `#tfc:mortar`]),
 			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}_narrow`, `railways:track_incomplete_${x.rail}_narrow`),
-		]).transitionalItem(`railways:track_incomplete_${x.rail}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_narrow_alt/wrought_iron`)
+		]).transitionalItem(`railways:track_incomplete_${x.rail}_narrow`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_narrow_alt`)
 
-		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_narrow_alt/wrought_iron`)
-			.itemInputs(x.slab, `2x #forge:rods/wrought_iron`)
+		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_narrow_alt`)
+			.itemInputs(x.slab, `2x #tfg:track_rods`)
 			.inputFluids(Fluid.of(`gtceu:concrete`, 144))
 			.itemOutputs(`16x railways:track_${x.rail}_narrow`)
 			.duration(800)
@@ -776,85 +676,35 @@ const registerRailWaysRecipes = (event) => {
 			.circuit(1)
 
 		event.recipes.createSequencedAssembly([
-			`32x railways:track_${x.rail}_narrow`,
-		], x.slab, [
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_narrow`, [`railways:track_incomplete_${x.rail}_narrow`, `#forge:rods/steel`]),
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_narrow`, [`railways:track_incomplete_${x.rail}_narrow`, `#tfc:mortar`]),
-			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}_narrow`, `railways:track_incomplete_${x.rail}_narrow`),
-		]).transitionalItem(`tfg:track_incomplete_${x.rail}_narrow_steel`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_narrow_alt/steel`)
-
-		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_narrow_alt/steel`)
-			.itemInputs(x.slab, `2x #forge:rods/steel`)
-			.inputFluids(Fluid.of(`gtceu:concrete`, 144))
-			.itemOutputs(`32x railways:track_${x.rail}_narrow`)
-			.duration(800)
-			.EUt(16)
-			.circuit(1)
-
-		event.recipes.createSequencedAssembly([
-			`16x railways:track_${x.rail}`,
+			`32x railways:track_${x.rail}`,
 		], x.slab, [
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, x.slab]),
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, `#forge:rods/wrought_iron`]),
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, `#tfg:track_rods`]),
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, `#tfc:mortar`]),
 			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}`, `railways:track_incomplete_${x.rail}`),
-		]).transitionalItem(`railways:track_incomplete_${x.rail}`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_alt/wrought_iron`)
+		]).transitionalItem(`railways:track_incomplete_${x.rail}`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_alt`)
 
-		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_normal_alt/wrought_iron`)
-			.itemInputs(`3x ${x.slab}`, `2x #forge:rods/wrought_iron`)
+		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_normal_alt`)
+			.itemInputs(`3x ${x.slab}`, `2x #tfg:track_rods`)
 			.inputFluids(Fluid.of(`gtceu:concrete`, 144))
 			.itemOutputs(`16x railways:track_${x.rail}`)
 			.duration(800)
 			.EUt(16)
 			.circuit(2)
-			
-		event.recipes.createSequencedAssembly([
-			`32x railways:track_${x.rail}`,
-		], x.slab, [
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, x.slab]),
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, `#forge:rods/steel`]),
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}`, [`railways:track_incomplete_${x.rail}`, `#tfc:mortar`]),
-			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}`, `railways:track_incomplete_${x.rail}`),
-		]).transitionalItem(`tfg:track_incomplete_${x.rail}_steel`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_alt/steel`)
-
-		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_normal_alt/steel`)
-			.itemInputs(`3x ${x.slab}`, `2x #forge:rods/steel`)
-			.inputFluids(Fluid.of(`gtceu:concrete`, 144))
-			.itemOutputs(`32x railways:track_${x.rail}`)
-			.duration(800)
-			.EUt(16)
-			.circuit(2)
-
-		event.recipes.createSequencedAssembly([
-			`16x railways:track_${x.rail}_wide`,
-		], x.slab, [
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, x.block]),
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, `#forge:rods/wrought_iron`]),
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, `#tfc:mortar`]),
-			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}_wide`, `railways:track_incomplete_${x.rail}_wide`),
-		]).transitionalItem(`railways:track_incomplete_${x.rail}_wide`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_wide_alt/wrought_iron`)
-
-		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_wide_alt/wrought_iron`)
-			.itemInputs(`5x ${x.slab}`, `2x #forge:rods/wrought_iron`)
-			.inputFluids(Fluid.of(`gtceu:concrete`, 144))
-			.itemOutputs(`16x railways:track_${x.rail}_wide`)
-			.duration(800)
-			.EUt(16)
-			.circuit(3)
 
 		event.recipes.createSequencedAssembly([
 			`32x railways:track_${x.rail}_wide`,
 		], x.slab, [
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, x.block]),
-			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, `#forge:rods/steel`]),
+			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, `#tfg:track_rods`]),
 			event.recipes.createDeploying(`railways:track_incomplete_${x.rail}_wide`, [`railways:track_incomplete_${x.rail}_wide`, `#tfc:mortar`]),
 			event.recipes.greate.pressing(`railways:track_incomplete_${x.rail}_wide`, `railways:track_incomplete_${x.rail}_wide`),
-		]).transitionalItem(`tfg:track_incomplete_${x.rail}_wide_steel`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_wide_alt/steel`)
+		]).transitionalItem(`railways:track_incomplete_${x.rail}_wide`).loops(2).id(`tfg:railways/sequenced_assembly/track_${x.rail}_wide_alt`)
 
-		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_wide_alt/steel`)
-			.itemInputs(`5x ${x.slab}`, `2x #forge:rods/steel`)
+		event.recipes.gtceu.assembler(`tfg:railways/track_${x.rail}_wide_alt`)
+			.itemInputs(`5x ${x.slab}`, `2x #tfg:track_rods`)
 			.inputFluids(Fluid.of(`gtceu:concrete`, 144))
-			.itemOutputs(`32x railways:track_${x.rail}_wide`)
+			.itemOutputs(`16x railways:track_${x.rail}_wide`)
 			.duration(800)
 			.EUt(16)
 			.circuit(3)

--- a/kubejs/server_scripts/tfg/tags.js
+++ b/kubejs/server_scripts/tfg/tags.js
@@ -164,7 +164,8 @@ const registerTFGItemTags = (event) => {
 		event.add("c:hidden_from_recipe_viewers", glassLens);
 	});
 	
-	//tag unfinished tracks for emi++ grouping
+	event.add('tfg:track_rods', '#forge:rods/long/wrought_iron')
+	event.add('tfg:track_rods', '#forge:rods/steel')
 	
 	global.TFC_WOOD_TYPES.forEach(wood => {
 		event.add('c:hidden_from_recipe_viewers', `railways:track_incomplete_tfc_${wood}`)

--- a/kubejs/server_scripts/tfg/tags.js
+++ b/kubejs/server_scripts/tfg/tags.js
@@ -167,9 +167,9 @@ const registerTFGItemTags = (event) => {
 	//tag unfinished tracks for emi++ grouping
 	
 	global.TFC_WOOD_TYPES.forEach(wood => {
-		event.add('tfg:incomplete_tracks', `railways:track_incomplete_tfc_${wood}`)
-		event.add('tfg:incomplete_tracks', `railways:track_incomplete_tfc_${wood}_narrow`)
-		event.add('tfg:incomplete_tracks', `railways:track_incomplete_tfc_${wood}_wide`)	
+		event.add('c:hidden_from_recipe_viewers', `railways:track_incomplete_tfc_${wood}`)
+		event.add('c:hidden_from_recipe_viewers', `railways:track_incomplete_tfc_${wood}_narrow`)
+		event.add('c:hidden_from_recipe_viewers', `railways:track_incomplete_tfc_${wood}_wide`)	
 	})
 	
 	const OTHER_TRACKS = [
@@ -180,12 +180,12 @@ const registerTFGItemTags = (event) => {
 	]
 	
 	OTHER_TRACKS.forEach(rail => {
-		event.add('tfg:incomplete_tracks', `railways:track_incomplete_${rail}`)
-		event.add('tfg:incomplete_tracks', `railways:track_incomplete_${rail}_narrow`)
-		event.add('tfg:incomplete_tracks', `railways:track_incomplete_${rail}_wide`)
+		event.add('c:hidden_from_recipe_viewers', `railways:track_incomplete_${rail}`)
+		event.add('c:hidden_from_recipe_viewers', `railways:track_incomplete_${rail}_narrow`)
+		event.add('c:hidden_from_recipe_viewers', `railways:track_incomplete_${rail}_wide`)
 	})
 	
-	event.add('tfg:incomplete_tracks', `railways:track_incomplete_monorail`)
+	event.add('c:hidden_from_recipe_viewers', `railways:track_incomplete_monorail`)
 	
 	// tag locometal blocks (minus (trap)doors) for emi++ grouping
 

--- a/kubejs/startup_scripts/tfg/items.js
+++ b/kubejs/startup_scripts/tfg/items.js
@@ -84,49 +84,4 @@ const registerTFGItems = (event) => {
 	event.create('tfg:worked_optical_borosilicate_blank')
 		.texture('tfg:item/worked_optical_borosilicate_blank')
 		.tag('tfg:precision_fabricator_dipped_items')
-
-	// Train Tracks
-	const OTHER_TRACKS = [
-		'blackstone', 'tieless', 'acacia', 'birch', 'cherry', 'jungle', 'spruce', 'crimson', 'warped', 'stripped_bamboo', 'bamboo'
-	]
-
-	event.create('tfg:track_incomplete_create_andesite_steel', 'create:sequenced_assembly')
-		.texture('railways:item/track_incomplete/track_incomplete_create_andesite')
-		.tag('c:hidden_from_recipe_viewers')
-
-	event.create('tfg:track_incomplete_create_andesite_narrow_steel', 'create:sequenced_assembly')
-		.texture('railways:item/track_incomplete/track_incomplete_create_andesite_narrow')
-		.tag('c:hidden_from_recipe_viewers')
-
-	event.create('tfg:track_incomplete_create_andesite_wide_steel', 'create:sequenced_assembly')
-		.texture('railways:item/track_incomplete/track_incomplete_create_andesite_wide')
-		.tag('c:hidden_from_recipe_viewers')
-	
-	OTHER_TRACKS.forEach(type => {
-		event.create(`tfg:track_incomplete_${type}_steel`, 'create:sequenced_assembly')
-			.texture(`railways:item/track_incomplete/track_incomplete_${type}`)
-			.tag('c:hidden_from_recipe_viewers')
-
-		event.create(`tfg:track_incomplete_${type}_narrow_steel`, 'create:sequenced_assembly')
-			.texture(`railways:item/track_incomplete/track_incomplete_${type}_narrow`)
-			.tag('c:hidden_from_recipe_viewers')
-			
-		event.create(`tfg:track_incomplete_${type}_wide_steel`, 'create:sequenced_assembly')
-			.texture(`railways:item/track_incomplete/track_incomplete_${type}_wide`)
-			.tag('c:hidden_from_recipe_viewers')
-	})
-
-	global.TFC_WOOD_TYPES.forEach(woodType => {
-		event.create(`tfg:track_incomplete_tfc_${woodType}_steel`, 'create:sequenced_assembly')
-			.texture(`tfc:item/track_incomplete/track_incomplete_${woodType}`)
-			.tag('c:hidden_from_recipe_viewers')
-
-		event.create(`tfg:track_incomplete_tfc_${woodType}_narrow_steel`, 'create:sequenced_assembly')
-			.texture(`tfc:item/track_incomplete/track_incomplete_${woodType}_narrow`)
-			.tag('c:hidden_from_recipe_viewers')
-
-		event.create(`tfg:track_incomplete_tfc_${woodType}_wide_steel`, 'create:sequenced_assembly')
-			.texture(`tfc:item/track_incomplete/track_incomplete_${woodType}_wide`)
-			.tag('c:hidden_from_recipe_viewers')
-	})
 }

--- a/kubejs/startup_scripts/tfg/items.js
+++ b/kubejs/startup_scripts/tfg/items.js
@@ -85,4 +85,48 @@ const registerTFGItems = (event) => {
 		.texture('tfg:item/worked_optical_borosilicate_blank')
 		.tag('tfg:precision_fabricator_dipped_items')
 
+	// Train Tracks
+	const OTHER_TRACKS = [
+		'blackstone', 'tieless', 'acacia', 'birch', 'cherry', 'jungle', 'spruce', 'crimson', 'warped', 'stripped_bamboo', 'bamboo'
+	]
+
+	event.create('tfg:track_incomplete_create_andesite_steel', 'create:sequenced_assembly')
+		.texture('railways:item/track_incomplete/track_incomplete_create_andesite')
+		.tag('c:hidden_from_recipe_viewers')
+
+	event.create('tfg:track_incomplete_create_andesite_narrow_steel', 'create:sequenced_assembly')
+		.texture('railways:item/track_incomplete/track_incomplete_create_andesite_narrow')
+		.tag('c:hidden_from_recipe_viewers')
+
+	event.create('tfg:track_incomplete_create_andesite_wide_steel', 'create:sequenced_assembly')
+		.texture('railways:item/track_incomplete/track_incomplete_create_andesite_wide')
+		.tag('c:hidden_from_recipe_viewers')
+	
+	OTHER_TRACKS.forEach(type => {
+		event.create(`tfg:track_incomplete_${type}_steel`, 'create:sequenced_assembly')
+			.texture(`railways:item/track_incomplete/track_incomplete_${type}`)
+			.tag('c:hidden_from_recipe_viewers')
+
+		event.create(`tfg:track_incomplete_${type}_narrow_steel`, 'create:sequenced_assembly')
+			.texture(`railways:item/track_incomplete/track_incomplete_${type}_narrow`)
+			.tag('c:hidden_from_recipe_viewers')
+			
+		event.create(`tfg:track_incomplete_${type}_wide_steel`, 'create:sequenced_assembly')
+			.texture(`railways:item/track_incomplete/track_incomplete_${type}_wide`)
+			.tag('c:hidden_from_recipe_viewers')
+	})
+
+	global.TFC_WOOD_TYPES.forEach(woodType => {
+		event.create(`tfg:track_incomplete_tfc_${woodType}_steel`, 'create:sequenced_assembly')
+			.texture(`tfc:item/track_incomplete/track_incomplete_${woodType}`)
+			.tag('c:hidden_from_recipe_viewers')
+
+		event.create(`tfg:track_incomplete_tfc_${woodType}_narrow_steel`, 'create:sequenced_assembly')
+			.texture(`tfc:item/track_incomplete/track_incomplete_${woodType}_narrow`)
+			.tag('c:hidden_from_recipe_viewers')
+
+		event.create(`tfg:track_incomplete_tfc_${woodType}_wide_steel`, 'create:sequenced_assembly')
+			.texture(`tfc:item/track_incomplete/track_incomplete_${woodType}_wide`)
+			.tag('c:hidden_from_recipe_viewers')
+	})
 }


### PR DESCRIPTION

### What is the new behavior?
- Creates new sequenced items to make steel versions of the recipes properly function. 
- Made all inomplete train tracks be hidden from recipe view (clicking or right clicking on them gives no information).
- Fixed a bug with pyroxenite incomplete tracks being used in create:track sequenced recipe.

### Additional Information
- Fixes #4023
- Moved some stuff around in the railways file just in case I need to work with it later.