### PR TITLE
Fix firmalife's dynamic food sizes being applied nondeterministically

### DIFF
--- a/kubejs/data/firmalife/tfc/item_sizes/dynamic_foods.json
+++ b/kubejs/data/firmalife/tfc/item_sizes/dynamic_foods.json
@@ -1,0 +1,7 @@
+{
+  "ingredient": {
+    "item": "firmalife:foods/dynamic"
+  },
+  "size": "very_small",
+  "weight": "medium"
+}

--- a/kubejs/server_scripts/firmalife/data.js
+++ b/kubejs/server_scripts/firmalife/data.js
@@ -11,14 +11,5 @@ const registerFirmalifeItemSize = (event) => {
     event.itemSize('firmalife:jar/compost', 'tiny', 'medium', 'jar_of_compost')
     event.itemSize('firmalife:jar/rotten_compost', 'tiny', 'medium', 'jar_of_rotten_compost')
     event.itemSize('firmalife:jar/guano', 'tiny', 'medium', 'jar_of_guano')
-    
-    // fix firmalife food dupe patch
-	event.itemSize('firmalife:food/cooked_pizza', 'very_small', 'medium')
-	event.itemSize('firmalife:food/burrito', 'very_small', 'medium')
-	event.itemSize('firmalife:food/taco', 'very_small', 'medium')
-	event.itemSize('firmalife:food/cooked_pie', 'very_small', 'medium')
-	event.itemSize('firmalife:food/filled_pie', 'very_small', 'medium')
-	event.itemSize('firmalife:food/raw_pizza', 'very_small', 'medium')
-	event.itemSize('firmalife:food/stinky_soup', 'very_small', 'medium')
 }
 //#endregion


### PR DESCRIPTION
Food sizes were being applied nondeterministically only to some foods. Reliably only after a /reload

> I talked to mail man about it before and they said that it doesn't always work for overwriting values. Sometimes using a json with the same path is the only way. 
