### PR TITLE
GTCEu Speed Boosting Block BlockRunner Config

### DIFF
--- a/config/blockrunner.json
+++ b/config/blockrunner.json
@@ -25,5 +25,8 @@
 	"#rnr:functional_concrete_road_slabs": 1.3,
 	"#tfg:functional_asphalt_roads": 1.4,
 	"#tfg:functional_asphalt_road_stairs": 1.4,
-	"#tfg:functional_asphalt_road_slabs": 1.4
+	"#tfg:functional_asphalt_road_slabs": 1.4,
+	"#forge:very_fast_walkable_blocks": 1.2,
+	"#forge:fast_walkable_blocks": 1.08,
+	"#forge:slow_walkable_blocks": 0.8
 }


### PR DESCRIPTION

### What is the new behavior?
Adds a block runner entry for GTCEu's speed-modifying blocks. Also nerfs speeds.

### Implementation Details
- Concrete is now 1.2
- Studs are 1.1
- Frames are 0.8 (about the same)

### Additional Information
- Closes #4043