### PR TITLE
fix: fix lootpool for nether wastes enderman

### DIFF
--- a/kubejs/data/endermanoverhaul/loot_tables/entities/nether_wastes_enderman.json
+++ b/kubejs/data/endermanoverhaul/loot_tables/entities/nether_wastes_enderman.json
@@ -41,19 +41,25 @@
 			"rolls": 2.0
 		},
 		{
-			"type": "minecraft:item",
-			"functions": [
+			"bonus_rolls": 0.0,
+			"entries": [
 				{
-					"add": false,
-					"count": {
-						"type": "minecraft:uniform",
-						"max": 4.0,
-						"min": 2.0
-					},
-					"function": "minecraft:set_count"
+					"type": "minecraft:item",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4.0,
+								"min": 2.0
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "tfc:ore/normal_native_gold"
 				}
 			],
-			"name": "tfc:ore/normal_native_gold"
+			"rolls": 1.0
 		}
 	]
 }


### PR DESCRIPTION
## What is the new behavior?
Fix wrong loot table for nether_wastes_enderman

## Implementation Details
this error happens everytime starting the game:

```
[10:25:59] [Worker-ResourceReload-1/ERROR] [ne.mi.co.ForgeHooks/]: Couldn't parse element loot_tables:endermanoverhaul:entities/nether_wastes_enderman
com.google.gson.JsonSyntaxException: Missing entries
	at net.minecraft.util.GsonHelper.m_13836_(GsonHelper.java:473) ~[client-1.20.1-20230612.114412-srg.jar%23657!/:?] {re:classloading,re:mixin}
	at net.minecraft.world.level.storage.loot.LootPool$Serializer.deserialize(LootPool.java:192) ~[client-1.20.1-20230612.114412-srg.jar%23657!/:?] {re:classloading}
	at net.minecraft.world.level.storage.loot.LootPool$Serializer.deserialize(LootPool.java:189) ~[client-1.20.1-20230612.114412-srg.jar%23657!/:?] {re:classloading}
	at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:76) ~[gson-2.10.jar%2374!/:?] {}
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40) ~[gson-2.10.jar%2374!/:?] {}
	at com.google.gson.internal.bind.ArrayTypeAdapter.read(ArrayTypeAdapter.java:72) ~[gson-2.10.jar%2374!/:?] {}
	at com.google.gson.Gson.fromJson(Gson.java:1214) ~[gson-2.10.jar%2374!/:?] {re:mixin}
	at com.google.gson.Gson.fromJson(Gson.java:1319) ~[gson-2.10.jar%2374!/:?] {re:mixin}
	at com.google.gson.Gson.fromJson(Gson.java:1290) ~[gson-2.10.jar%2374!/:?] {re:mixin}
	at com.google.gson.internal.bind.TreeTypeAdapter$GsonContextImpl.deserialize(TreeTypeAdapter.java:179) ~[gson]
```

## Outcome
the error goes away