### PR TITLE
Added mars creatures to the pastoral_engine recipes

### DIFF
--- a/kubejs/server_scripts/tfg/machines/recipes.pastoral.js
+++ b/kubejs/server_scripts/tfg/machines/recipes.pastoral.js
@@ -24,6 +24,27 @@ function registerTFGPastoralRecipes(event) {
         .circuit(3)
     TFGRecipeSchemaBindings.animalPresentEntity(milk_goat, 'tfc:goat')
 
+    let glacian_wool = event.recipes.gtceu.pastoral_engine('tfg:shear_glacian')
+        .itemOutputs(Item.of('tfg:glacian_wool'))
+        .duration(20 * 5)
+        .EUt(GTValues.VA[GTValues.LV])
+        .circuit(5)
+    TFGRecipeSchemaBindings.animalPresentEntity(glacian_wool, 'tfg:glacian_ram')
+
+    let sniffer_wool = event.recipes.gtceu.pastoral_engine('tfg:shear_sniffer')
+        .itemOutputs(Item.of('tfg:sniffer_wool'))
+        .duration(20 * 5)
+        .EUt(GTValues.VA[GTValues.LV])
+        .circuit(6)
+    TFGRecipeSchemaBindings.animalPresent(sniffer_wool, 'producing')
+
+    let wraptor_wool = event.recipes.gtceu.pastoral_engine('tfg:shear_wraptor')
+        .itemOutputs(Item.of('tfg:wraptor_wool'))
+        .duration(20 * 5)
+        .EUt(GTValues.VA[GTValues.LV])
+        .circuit(7)
+    TFGRecipeSchemaBindings.animalPresent(wraptor_wool, 'producing')
+
     // Category
     let wool = event.recipes.gtceu.pastoral_engine('tfg:shear_wool')
         .itemOutputs(Item.of('tfc:wool'))

--- a/kubejs/server_scripts/tfg/machines/recipes.pastoral.js
+++ b/kubejs/server_scripts/tfg/machines/recipes.pastoral.js
@@ -24,6 +24,15 @@ function registerTFGPastoralRecipes(event) {
         .circuit(3)
     TFGRecipeSchemaBindings.animalPresentEntity(milk_goat, 'tfc:goat')
 
+    // Category of generic wool producers
+    let wool = event.recipes.gtceu.pastoral_engine('tfg:shear_wool')
+        .itemOutputs(Item.of('tfc:wool'))
+		.duration(20 * 5)
+		.EUt(GTValues.VA[GTValues.LV])
+        .circuit(4)
+    TFGRecipeSchemaBindings.animalPresent(wool, 'producing')
+
+    // Mars animals
     let glacian_wool = event.recipes.gtceu.pastoral_engine('tfg:shear_glacian')
         .itemOutputs(Item.of('tfg:glacian_wool'))
         .duration(20 * 5)
@@ -44,13 +53,5 @@ function registerTFGPastoralRecipes(event) {
         .EUt(GTValues.VA[GTValues.LV])
         .circuit(7)
     TFGRecipeSchemaBindings.animalPresent(wraptor_wool, 'producing')
-
-    // Category
-    let wool = event.recipes.gtceu.pastoral_engine('tfg:shear_wool')
-        .itemOutputs(Item.of('tfc:wool'))
-		.duration(20 * 5)
-		.EUt(GTValues.VA[GTValues.LV])
-        .circuit(4)
-    TFGRecipeSchemaBindings.animalPresent(wool, 'producing')
 
 }


### PR DESCRIPTION
## What is the new behavior?
This just includes the 'wooly' mars creatures into the `recipes.pastoral.js` file for the pastoral rancher multiblock.

## Implementation Details
Adding Glacians was rather straightforward, but Wraptors and Sniffers are a non-standard TFC mob type called `WoolEggProducingAnimals`, and the methods they inherit from `ProducingAnimal` that is used by the KubeJs bindings store data on the animal's eggs, instead of wool. As a result this PR is dependent upon [#466](https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/466) in Core-Modern.

Wraptors and Sniffers use 'producing' as the animalType parameter so that testCondition() within `AnimalPresentCondition.java` knows to check for hasWool instead of .isReadyForAnimalProduct() which refers to these animal's egg timers.

## Outcome
- Added recipes for Wraptors, Sniffers, and Glacian Rams' 'wool' products to the Pastoral Rancher Multiblock.

## Potential Compatibility Issues
The recipes use programming circuit 5, 6 and 7, so it may conflict with other recipes in the pastoral rancher that use those circuit numbers in the future.