### PR TITLE
Make a bunch of items replaceable by tracks

### DIFF
--- a/kubejs/server_scripts/afc/tags.js
+++ b/kubejs/server_scripts/afc/tags.js
@@ -119,8 +119,10 @@ const registerAFCBlockTags = (event) => {
 		event.add('minecraft:mineable/axe', `afc:wood/stomping_barrel/${wood}`)
 		event.add('minecraft:mineable/axe', `afc:wood/barrel_press/${wood}`)
 		event.add('minecraft:mineable/axe', `afc:wood/wine_shelf/${wood}`)
-        event.add('tfc:can_be_snow_piled', `afc:wood/twig/${woodType}`)
 	})
+    global.AFC_SAPLINGS.forEach(tree => {
+        event.add('tfc:can_be_snow_piled', `afc:wood/twig/${tree.sapling}`)
+    })
 
 	event.add("afc:tappable_logs", "tfc:wood/log/ancient_kapok")
 	event.add("afc:tappable_logs", "tfc:wood/log/kapok")

--- a/kubejs/server_scripts/afc/tags.js
+++ b/kubejs/server_scripts/afc/tags.js
@@ -23,7 +23,6 @@ const registerAFCItemTags = (event) => {
 		event.add('tfc:jar_shelves', `afc:wood/jar_shelf/${woodType}`)
 		event.add('tfc:minecarts', `afc:wood/chest_minecart/${woodType}`)
 		event.add('minecraft:signs', `afc:wood/sign/${woodType}`)
-        event.add('tfc:can_be_snow_piled', `afc:wood/twig/${woodType}`)
 
 		global.TFC_EQUIPMENT_METALS.forEach(metalType => {
 			event.add('minecraft:hanging_signs', `afc:wood/hanging_sign/${metalType}/${woodType}`)
@@ -120,6 +119,7 @@ const registerAFCBlockTags = (event) => {
 		event.add('minecraft:mineable/axe', `afc:wood/stomping_barrel/${wood}`)
 		event.add('minecraft:mineable/axe', `afc:wood/barrel_press/${wood}`)
 		event.add('minecraft:mineable/axe', `afc:wood/wine_shelf/${wood}`)
+        event.add('tfc:can_be_snow_piled', `afc:wood/twig/${woodType}`)
 	})
 
 	event.add("afc:tappable_logs", "tfc:wood/log/ancient_kapok")

--- a/kubejs/server_scripts/afc/tags.js
+++ b/kubejs/server_scripts/afc/tags.js
@@ -23,6 +23,7 @@ const registerAFCItemTags = (event) => {
 		event.add('tfc:jar_shelves', `afc:wood/jar_shelf/${woodType}`)
 		event.add('tfc:minecarts', `afc:wood/chest_minecart/${woodType}`)
 		event.add('minecraft:signs', `afc:wood/sign/${woodType}`)
+        event.add('tfc:can_be_snow_piled', `afc:wood/twig/${woodType}`)
 
 		global.TFC_EQUIPMENT_METALS.forEach(metalType => {
 			event.add('minecraft:hanging_signs', `afc:wood/hanging_sign/${metalType}/${woodType}`)

--- a/kubejs/server_scripts/create/tags.js
+++ b/kubejs/server_scripts/create/tags.js
@@ -191,7 +191,6 @@ const registerCreateBlockTags = (event) => {
 	event.add('tfc:no_icicle_generation', 'create:chain_conveyor')
 
     event.add('tfg:track_replaceable', '#tfc:can_be_snow_piled')
-    event.add('tfg:track_replaceable', '#tfc:twigs')
 }
 
 

--- a/kubejs/server_scripts/create/tags.js
+++ b/kubejs/server_scripts/create/tags.js
@@ -189,6 +189,9 @@ const registerCreateBlockTags = (event) => {
 	event.add('create:non_movable', 'tfg:mafic_hornfels')
 
 	event.add('tfc:no_icicle_generation', 'create:chain_conveyor')
+
+    event.add('tfg:track_replaceable', '#tfc:can_be_snow_piled')
+    event.add('tfg:track_replaceable', '#tfc:twigs')
 }
 
 


### PR DESCRIPTION
fixes #4136

can_be_snow_piled seems to include everything listed in the issue except for afc and tfg twigs

this voids the replaced blocks

https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/480
