### PR TITLE
Paving cart shouldn't be very_small and very_light

### DIFF
--- a/kubejs/server_scripts/tfg/data.js
+++ b/kubejs/server_scripts/tfg/data.js
@@ -91,6 +91,7 @@ function registerTFGItemSize(event) {
 	event.itemSize("tfg:fishing_net/magnalium", "large", "medium", "magnalium_fishing_net");
 
 	event.itemSize("tfg:trowel", "large", "medium", "trowel");
+	event.itemSize("tfg:rnr_plow", "very_large", "heavy", "rnr_plow");
 
 	event.itemSize("tfg:railgun_ammo_shell", "large", "light", "railgun_ammo_shell");
 	event.itemSize("tfg:quartz_crucible", "large", "very_heavy", "quartz_crucible");


### PR DESCRIPTION
## What is the new behavior?
Make paving cart very_large and heavy, instead of very_small and very_light