### PR TITLE
Fixes Lunch Boxes Voiding Inventory on Upgrades

### DIFF
--- a/kubejs/server_scripts/tfclunchbox/recipes.js
+++ b/kubejs/server_scripts/tfclunchbox/recipes.js
@@ -2,4 +2,91 @@
 "use strict";
 
 function registerTFCLunchBoxRecipes(event) {
+    event.remove({ id: 'tfclunchbox:upgrade_to_cooling_lunchbox' })
+    event.remove({ id: 'tfclunchbox:electric_lunchbox' })
+
+    event.shaped('tfclunchbox:cooling_lunchbox', [
+        ' A ',
+        'BCB'
+    ], {
+		A: '#forge:tools/hammers',
+		B: '#forge:sheets/red_steel',
+        C: 'tfclunchbox:lunchbox'
+	}).id('tfg:shaped/upgrade_to_cooling_lunchbox')
+    .modifyResult((grid, result) => {
+			let orig = grid.find(Item.of('tfclunchbox:lunchbox'))
+
+			if (orig.nbt == null) {
+				return result;
+			} else {
+                delete orig.nbt.display;
+				return result.withNBT({
+                    Items: {
+                        Items: orig.nbt.Items.Items
+                    }
+                });
+			}
+		})
+
+    event.shaped('tfclunchbox:electric_lunchbox', [
+        ' AB',
+        'CDC',
+        'EFE'
+    ], {
+		A: '#forge:fine_wires/copper',
+        B: '#forge:tools/hammers',
+		C: '#forge:sheets/blue_steel',
+        D: 'tfclunchbox:cooling_lunchbox',
+        E: '#forge:screws/steel',
+        F: '#gtceu:circuits/lv'
+	}).id('tfg:shaped/upgrade_to_electric_lunchbox')
+    .modifyResult((grid, result) => {
+			let orig = grid.find(Item.of('tfclunchbox:cooling_lunchbox'))
+
+			if (orig.nbt == null) {
+				return result;
+			} else {
+                delete orig.nbt.display;
+				return result.withNBT({
+                    Items: {
+                        Items: orig.nbt.Items.Items
+                    }
+                });
+			}
+		})
+
+    /* event.shapeless('toolbelt:belt', ['toolbelt:belt', 'toolbelt:pouch'])
+		.modifyResult((grid, result) => {
+			let orig = grid.find(Item.of('toolbelt:belt').ignoreNBT())
+
+			if (orig.nbt == null) {
+				orig.nbt = { Size: 3 };
+			}
+			else {
+				if (orig.nbt.Size == null) {
+					orig.nbt = { Size: 3 };
+				}
+				else {
+					orig.nbt.Size = orig.nbt.getInt("Size") + 1;
+				}
+			}
+
+			return result.withNBT(orig.nbt);
+		})
+
+
+	event.shapeless('toolbelt:belt', ['toolbelt:belt', 'tfc:powder/wood_ash'])
+		.modifyResult((grid, result) => {
+			let orig = grid.find(Item.of('toolbelt:belt').ignoreNBT())
+
+			if (orig.nbt == null || orig.nbt.display == null) {
+				return result;
+			}
+			else {
+				delete orig.nbt.display;
+				return result.withNBT(orig.nbt);
+			}
+		})*/
+
+        
 }

--- a/kubejs/server_scripts/tfclunchbox/recipes.js
+++ b/kubejs/server_scripts/tfclunchbox/recipes.js
@@ -54,39 +54,4 @@ function registerTFCLunchBoxRecipes(event) {
                 });
 			}
 		})
-
-    /* event.shapeless('toolbelt:belt', ['toolbelt:belt', 'toolbelt:pouch'])
-		.modifyResult((grid, result) => {
-			let orig = grid.find(Item.of('toolbelt:belt').ignoreNBT())
-
-			if (orig.nbt == null) {
-				orig.nbt = { Size: 3 };
-			}
-			else {
-				if (orig.nbt.Size == null) {
-					orig.nbt = { Size: 3 };
-				}
-				else {
-					orig.nbt.Size = orig.nbt.getInt("Size") + 1;
-				}
-			}
-
-			return result.withNBT(orig.nbt);
-		})
-
-
-	event.shapeless('toolbelt:belt', ['toolbelt:belt', 'tfc:powder/wood_ash'])
-		.modifyResult((grid, result) => {
-			let orig = grid.find(Item.of('toolbelt:belt').ignoreNBT())
-
-			if (orig.nbt == null || orig.nbt.display == null) {
-				return result;
-			}
-			else {
-				delete orig.nbt.display;
-				return result.withNBT(orig.nbt);
-			}
-		})*/
-
-        
 }


### PR DESCRIPTION

## What is the new behavior?
Fixes Lunch Boxes voiding their inventory when upgraded in crafting recipes.

## Outcome
- Fixes #4157