### PR TITLE
fix: wrong item id in sandy_jadestone_spike loot table

### DIFF
--- a/kubejs/data/tfg/loot_tables/blocks/spike/sandy_jadestone_spike.json
+++ b/kubejs/data/tfg/loot_tables/blocks/spike/sandy_jadestone_spike.json
@@ -7,7 +7,7 @@
 			"entries": [
 				{
 					"type": "minecraft:item",
-					"name": "tfg:loose/sandy_jadestone_spike",
+					"name": "tfg:loose/sandy_jadestone",
 					"functions": [
 						{
 							"function": "minecraft:set_count",


### PR DESCRIPTION
## What is the new behavior?
Fix wrong item id in loot table:

```text
[05:40:55] [Worker-ResourceReload-0/ERROR] [ne.mi.co.ForgeHooks/]: Couldn't parse element loot_tables:tfg:blocks/spike/sandy_jadestone_spike
com.google.gson.JsonSyntaxException: Expected name to be an item, was unknown string 'tfg:loose/sandy_jadestone_spike'
	at net.minecraft.util.GsonHelper.m_13866_(GsonHelper.java:145) ~[client-1.20.1-20230612.114412-srg.jar%23661!/:?] {re:classloading,re:mixin}
	at java.util.Optional.orElseThrow(Optional.java:403) ~[?:?] {re:mixin}
	at net.minecraft.util.GsonHelper.m_13874_(GsonHelper.java:145) ~[client-1.20.1-20230612.114412-srg.jar%23661!/:?] {re:classloading,re:mixin}
	at net.minecraft.util.GsonHelper.m_13909_(GsonHelper.java:153) ~[client-1.20.1-20230612.114412-srg.jar%23661!/:?] {re:classloading,re:mixin}
	at net.minecraft.world.level.storage.loot.entries.LootItem$Serializer.m_7267_(LootItem.java:55) ~[client-1.20.1-20230612.114412-srg.jar%23661!/:?] {re:classloading}
	at net.minecraft.world.level.storage.loot.entries.LootItem$Serializer.m_7267_(LootItem.java:40) ~[client-1.20.1-20230612.114412-srg.jar%23661!/:?] {re:classloading}
	at net.minecraft.world.level.storage.loot.entries.LootPoolSingletonContainer$Serializer.m_5921_(LootPoolSingletonContainer.java:151) ~[client-1.20.1-20230612.114412-srg.jar%23661!/:?] {re:classloading}
	at net.minecraft.world.level.storage.loot.entries.LootPoolSingletonContainer$Serializer.m_5921_(LootPoolSingletonContainer.java:129) ~[client-1.20.1-20230612.114412-srg.jar%23661!/:?] {re:classloading}
	at net.minecraft.world.level.storage.loot.entries.LootPoolEntryContainer$Serializer.m_7561_(LootPoolEntryContainer.java:86) ~[client-1.20.1-20230612.114412-srg.jar%23661!/:?] {re:classloading}
	at net.minecraft.world.level.storage.loot.entries.LootPoolEntryContainer$Serializer.m_7561_(LootPoolEntryContainer.java:74) ~
```