### PR TITLE
Add alternate rubbers to hazmat armor pieces

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -455,5 +455,28 @@ const registerGTCEURecipes = (event) => {
 
 	event.replaceInput({ id: 'gtceu:shaped/cracking_unit' }, '#gtceu:circuits/hv', '#gtceu:circuits/ev')
 
+  // Allow alternate rubbers for hazmat pieces
+
+  const ALTERNATE_RUBBERS = [
+		'silicone_rubber',
+		'styrene_butadiene_rubber',
+	]
+  ALTERNATE_RUBBERS.forEach(material => {	
+    event.recipes.gtceu.assembler(`gtceu:hazmat_chestpiece_${material}`)
+      .itemInputs(`2x #forge:plates/${material}`, '7x gtceu:polyvinyl_chloride_plate', '3x #forge:plates/lead')
+      .itemOutputs('gtceu:hazmat_chestpiece')
+      .duration(10*20)
+      .EUt(GTValues.VA[GTValues.LV])
+    event.recipes.gtceu.assembler(`gtceu:hazmat_leggings_${material}`)
+      .itemInputs(`2x #forge:plates/${material}`, '5x gtceu:polyvinyl_chloride_plate', '2x #forge:rods/iron', '4x #forge:rings/steel')
+      .itemOutputs('gtceu:hazmat_leggings')
+      .duration(10*20)
+      .EUt(GTValues.VA[GTValues.LV])
+    event.recipes.gtceu.assembler(`gtceu:hazmat_boots_${material}`)
+      .itemInputs(`4x #forge:plates/${material}`, '2x #forge:foils/polyethylene', '2x gtceu:polyvinyl_chloride_plate')
+      .itemOutputs('gtceu:hazmat_boots')
+      .duration(10*20)
+      .EUt(GTValues.VA[GTValues.LV])
+	})
 
 }

--- a/kubejs/server_scripts/gregtech/recipes.js
+++ b/kubejs/server_scripts/gregtech/recipes.js
@@ -457,26 +457,14 @@ const registerGTCEURecipes = (event) => {
 
   // Allow alternate rubbers for hazmat pieces
 
-  const ALTERNATE_RUBBERS = [
-		'silicone_rubber',
-		'styrene_butadiene_rubber',
-	]
-  ALTERNATE_RUBBERS.forEach(material => {	
-    event.recipes.gtceu.assembler(`gtceu:hazmat_chestpiece_${material}`)
-      .itemInputs(`2x #forge:plates/${material}`, '7x gtceu:polyvinyl_chloride_plate', '3x #forge:plates/lead')
-      .itemOutputs('gtceu:hazmat_chestpiece')
-      .duration(10*20)
-      .EUt(GTValues.VA[GTValues.LV])
-    event.recipes.gtceu.assembler(`gtceu:hazmat_leggings_${material}`)
-      .itemInputs(`2x #forge:plates/${material}`, '5x gtceu:polyvinyl_chloride_plate', '2x #forge:rods/iron', '4x #forge:rings/steel')
-      .itemOutputs('gtceu:hazmat_leggings')
-      .duration(10*20)
-      .EUt(GTValues.VA[GTValues.LV])
-    event.recipes.gtceu.assembler(`gtceu:hazmat_boots_${material}`)
-      .itemInputs(`4x #forge:plates/${material}`, '2x #forge:foils/polyethylene', '2x gtceu:polyvinyl_chloride_plate')
-      .itemOutputs('gtceu:hazmat_boots')
-      .duration(10*20)
-      .EUt(GTValues.VA[GTValues.LV])
-	})
+  const HAZMAT_PIECES_TO_REPLACE = [
+    "chestpiece",
+    "leggings",
+    "boots"
+  ]
+  HAZMAT_PIECES_TO_REPLACE.forEach(piece => {
+    event.replaceInput({ id: `gtceu:assembler/hazmat_${piece}` },
+      '#forge:plates/rubber', '#tfg:rubber_plates');
+  })
 
 }


### PR DESCRIPTION
## What is the new behavior?
Allows alternate rubbers (silicone, styrene butadiene) to be used in making of hazmat pieces. Stumbled upon a minor QoL problem where I don't have the raw, plant-based (latex) rubber when I needed to make a set. This should solve that, and we already have precedents with conveyor belts and pumps being allowed to be crafted using alternative rubber materials.

## Implementation Details
Simply adds an `event.recipes.gtceu.assembler` hook for-block in `gregtech/recipes.js`.

## Outcome
Adds new `gtceu:assembler/hazmat_[chestpiece | leggings | boots]_[silicone_rubber | styrene_butadiene_rubber]` recipe IDs using `event.recipes.gtceu.assembler`

## Additional Information
Ensured it matches the existing recipe using rubber (10 * 20 ticks, at 0.94A LV)
- Chestpiece
<img width="1532" height="920" alt="image" src="https://github.com/user-attachments/assets/cda7d3d3-886f-4e34-9f1e-f6ced2460223" />

- Leggings
<img width="1484" height="1059" alt="image" src="https://github.com/user-attachments/assets/a5cb54bf-519d-4bc6-ad02-f3a9bb6b583e" />

- Boots
<img width="1334" height="1047" alt="image" src="https://github.com/user-attachments/assets/f4af89e3-2e51-4498-8b99-1d9512b051c9" />


## Potential Compatibility Issues
Checked if a configuration circuit is needed -- doesn't seem to conflict with existing assembler recipes for silicone / styrene butadiene rubber so I'm deferring its usage for now.

Discord:
lickorice
319285994253975553
