### PR TITLE
Quest: align PCB progression with HV processing requirements

### DIFF
--- a/config/ftbquests/quests/chapters/hv__high_voltage.snbt
+++ b/config/ftbquests/quests/chapters/hv__high_voltage.snbt
@@ -1906,10 +1906,13 @@
 			dependencies: [
 				"390E59F05132FCB8"
 				"124B32A0583A636A"
+				"528CE69DA4358B2E"
 			]
 			description: ["{quests.high_voltage.alumina_board.desc}"]
+			hide_dependency_lines: true
 			id: "707596E5E9F01B8A"
 			optional: true
+			shape: "heart"
 			subtitle: "{quests.high_voltage.alumina_board.subtitle}"
 			tasks: [{
 				id: "32FDC591ACE9B2CF"


### PR DESCRIPTION
## What is the new behavior?

This PR improves progression clarity in the High Voltage PCB quest chain.

The PCB quest is now explicitly gated behind the Large Chemical Reactor quest (528CE69DA4358B2E), ensuring that players are correctly introduced to required processing infrastructure before attempting PCB production.

Additionally, this quest is marked as optional side content with adjusted UI presentation.

---

## Changes

- Add dependency on Large Chemical Reactor quest (528CE69DA4358B2E)
- Hide dependency lines for optional PCB quest node
- Set quest shape to HEART for side content classification

---

## Outcome

- PCB quest is now correctly gated behind LCR progression
- Improved clarity of HV progression path
- Optional PCB quest visually separated from main progression
- Reduced player confusion regarding missing processing requirements

---

## Implementation Details

- Modified FTB Quests SNBT quest definition
- Added LCR quest ID to dependency list
- Enabled `hide_dependency_lines` for cleaner UI
- Set `shape = "heart"` for optional quest classification

No changes to tasks, recipes, or progression logic beyond dependency gating.

---

## Potential Compatibility Issues

- None expected in existing worlds
- Quest progression graph remains acyclic
- No changes to quest IDs or tasks

---

## Additional Information

This change aligns PCB progression with existing HV machine gating already defined in the quest system.

---

Discord: od1n_hq