### PR TITLE
fix: add missing title for btx_loop quest

### DIFF
--- a/config/ftbquests/quests/chapters/ev__extreme_voltage.snbt
+++ b/config/ftbquests/quests/chapters/ev__extreme_voltage.snbt
@@ -2341,6 +2341,8 @@
 			]
 			icon: "gtceu:rhenium_dust"
 			id: "38184C7BA01A9B5B"
+			title: "{quests.extreme_voltage.btx_loop.title}"
+			subtitle: "{quests.extreme_voltage.btx_loop.subtitle}"
 			optional: true
 			shape: "circle"
 			tasks: [{


### PR DESCRIPTION
## What is the new behavior?
fix: add missing title for btx_loop quest