### PR TITLE
Remove wool and wool carpets as a fuel source

### DIFF
--- a/kubejs/startup_scripts/minecraft/modifications.js
+++ b/kubejs/startup_scripts/minecraft/modifications.js
@@ -19,11 +19,20 @@ function registerMinecraftItemModifications(event) {
 		item.maxDamage = 960
 	})
 
-	// Removes lava buckets as fuel
+	// Remove unneeded fuel sources
 
-	event.modify('minecraft:lava_bucket', item => {
-		item.burnTime = 0
-	})
+	event.modify("minecraft:lava_bucket", (item) => {
+		item.burnTime = 0;
+	});
+
+	global.MINECRAFT_DYE_NAMES.forEach((color) => {
+		event.modify(`minecraft:${color}_wool`, (item) => {
+			item.burnTime = 0;
+		});
+		event.modify(`minecraft:${color}_carpet`, (item) => {
+			item.burnTime = 0;
+		});
+	});
 
 	// Ladder burn time
 


### PR DESCRIPTION
## What is the new behavior?
https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/4073

## Implementation Details
I think there is some way of iterating thru a `#minecraft:wool` and `#minecraft:wool_carpet` tags, but i didn't find one. And as it seems, just iterating thru `global.MINECRAFT_DYE_NAMES` is common in this codebase

## Outcome
Fixes: https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/4073

## Additional Information
Discord: `mafien0`(i want to be a cool kid with the role)