### PR TITLE
fix server launch flags

### DIFF
--- a/.pakku/server-overrides/start_server.bat
+++ b/.pakku/server-overrides/start_server.bat
@@ -1,3 +1,3 @@
 @echo off
-java -jar -Xmx6024M -Xms1024M minecraft_server.jar nogui
+java -Xmx6024M -Xms1024M -jar minecraft_server.jar nogui
 pause

--- a/.pakku/server-overrides/start_server.bat
+++ b/.pakku/server-overrides/start_server.bat
@@ -1,3 +1,3 @@
 @echo off
-java -jar minecraft_server.jar -Xmx6024M -Xms1024M nogui
+java -jar -Xmx6024M -Xms1024M minecraft_server.jar nogui
 pause

--- a/.pakku/server-overrides/start_server.sh
+++ b/.pakku/server-overrides/start_server.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -jar minecraft_server.jar -Xmx6024M -Xms1024M nogui
+java -jar -Xmx6024M -Xms1024M minecraft_server.jar nogui

--- a/.pakku/server-overrides/start_server.sh
+++ b/.pakku/server-overrides/start_server.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -jar -Xmx6024M -Xms1024M minecraft_server.jar nogui
+java -Xmx6024M -Xms1024M -jar minecraft_server.jar nogui


### PR DESCRIPTION
## What is the new behavior?
start_server.sh and start_server.bat use the existing JVM memory flags as expected