### PR TITLE
fix: replace slab->wall chisel recipe with stairs->wall

### DIFF
--- a/kubejs/server_scripts/tfg/natural_blocks/recipes.rocks.js
+++ b/kubejs/server_scripts/tfg/natural_blocks/recipes.rocks.js
@@ -100,8 +100,8 @@ function registerTFGRockRecipes(event) {
 						.id(`tfg:stonecutting/${global.linuxUnfucker(blockEntry.block)}_to_${global.linuxUnfucker(blockEntry.wall)}`)
 				}
 			}
-			if (blockEntry.slab != null) {
-				event.recipes.tfc.chisel(blockEntry.wall, blockEntry.slab, 'smooth');
+			if (blockEntry.stair != null) {
+				event.recipes.tfc.chisel(blockEntry.wall, blockEntry.stair, 'smooth');
 			}
 		}
 	}


### PR DESCRIPTION
## What is the new behavior?
Under current implementation, full stone blocks can be chiseled into slabs, which can each be chiseled into walls, which can then be turned back into blocks through a stone cutter, effectively duping the original block. To fix this, stone stairs will be the source block when chiseling blocks into walls, which allows for a 1:1 conversion.


## Outcome
Fixes: #4254 

## Additional Information
<img width="1920" height="1080" alt="2026-06-13_21 48 56" src="https://github.com/user-attachments/assets/481cb987-4618-47fe-98ee-ce4ab5d64d28" />
<img width="1920" height="1080" alt="2026-06-13_21 49 01" src="https://github.com/user-attachments/assets/dc866403-c3e1-42ba-b1c0-d214dc4ae633" />
