### PR TITLE
fix: changed the candle->wax dust recipe to candle->small wax dust

### DIFF
--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -325,12 +325,12 @@ const registerTFCRecipes = (event) => {
 
 	event.recipes.gtceu.macerator('tfg:candle')
 		.itemInputs("#minecraft:candles")
-		.itemOutputs("#forge:dusts/wax")
+		.itemOutputs("#forge:small_dusts/wax")
 		.duration(50)
 		.EUt(2)
 		.category(GTRecipeCategories.MACERATOR_RECYCLING);
 	
-	event.recipes.tfc.quern("gtceu:wax_dust", "#minecraft:candles")
+	event.recipes.tfc.quern("#forge:small_dusts/wax", "#minecraft:candles")
 		.id("tfg:quern/candles")
 	event.recipes.tfc.quern("gtceu:tiny_wax_dust", "gtceu:wax_nugget")
 		.id("tfg:quern/wax_nugget")

--- a/kubejs/server_scripts/tfc/recipes.js
+++ b/kubejs/server_scripts/tfc/recipes.js
@@ -325,12 +325,12 @@ const registerTFCRecipes = (event) => {
 
 	event.recipes.gtceu.macerator('tfg:candle')
 		.itemInputs("#minecraft:candles")
-		.itemOutputs("#forge:small_dusts/wax")
+		.itemOutputs("gtceu:small_wax_dust")
 		.duration(50)
 		.EUt(2)
 		.category(GTRecipeCategories.MACERATOR_RECYCLING);
 	
-	event.recipes.tfc.quern("#forge:small_dusts/wax", "#minecraft:candles")
+	event.recipes.tfc.quern("gtceu:small_wax_dust", "#minecraft:candles")
 		.id("tfg:quern/candles")
 	event.recipes.tfc.quern("gtceu:tiny_wax_dust", "gtceu:wax_nugget")
 		.id("tfg:quern/wax_nugget")


### PR DESCRIPTION
## What is the new behavior?
Replaced the recipe for grinding down candles in the quern/millstone/crusher and macerator. Under current implementation, one candle becomes one wax dust, which means a player can duplicate wax at the cost of some string. This fix addresses that by ensuring that one candle grinds down into 1/4 of a wax dust: a small wax dust pile.

## Outcome
For the quern/millstone/crusher and the macerator, one candle produces one small wax dust pile, equivalent to 1/4 of the original material used, keeping the ratio of 1 wax:4 candles. Fixes #4263

## Additional Information
<img width="1920" height="1080" alt="2026-06-14_20 25 46" src="https://github.com/user-attachments/assets/f1f3ccac-39a0-40a7-bb37-44f6f45b889f" />