### PR TITLE
Restored recipes for copying configured filters

### DIFF
--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -5,7 +5,7 @@ const registerCreateRecipes = (event) => {
 
 	// Удаление рецептов мода create 
 	event.remove({
-		not: [			
+		not: [
 			{ id: 'create:crafting/kinetics/cuckoo_clock' },
 			{ id: 'create:crafting/kinetics/mysterious_cuckoo_clock' },
 			{ id: 'create:crafting/kinetics/smart_chute' },
@@ -48,15 +48,11 @@ const registerCreateRecipes = (event) => {
 			{ id: 'create:crafting/logistics/stock_link_clear'},
 			{ id: 'create:crafting/logistics/stock_ticker_clear'},
 			{ id: 'create:crafting/logistics/factory_gauge_clear'},
+			{ type: 'create:item_copying' },
 			{ output: '#create:table_cloths'} // Gotta do this to not purge the table cloth reset recipes
 		], mod: 'create'
 	})
-	
-	// Restore recipe for copying configured filters, schedules, and clipboards
-	event.custom({
-		type: 'create:item_copying'
-	}).id('kubejs:create_item_copying_restore')
-	
+
 	// Make Bound Cardboard craftable with all string
 	event.replaceInput({id: 'create:crafting/materials/bound_cardboard_block' }, 'minecraft:string', '#forge:string')
 	

--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -51,6 +51,12 @@ const registerCreateRecipes = (event) => {
 			{ output: '#create:table_cloths'} // Gotta do this to not purge the table cloth reset recipes
 		], mod: 'create'
 	})
+	
+	// Restore recipe for copying configured filters, schedules, and clipboards
+	event.custom({
+		type: 'create:item_copying'
+	}).id('kubejs:create_item_copying_restore')
+	
 	// Make Bound Cardboard craftable with all string
 	event.replaceInput({id: 'create:crafting/materials/bound_cardboard_block' }, 'minecraft:string', '#forge:string')
 	


### PR DESCRIPTION
## What is the new behavior?
Restored create recipes to copy configuration of filters in crafting grid.

Filled filter + Empty filter = 2x Filled filter

## Potential Compatibility Issues
None

Discord nickname: Robak132