### PR TITLE
fix: changed the recipe for the slash r road stencil

### DIFF
--- a/kubejs/server_scripts/tfg/primitive/recipes.artisan_table.js
+++ b/kubejs/server_scripts/tfg/primitive/recipes.artisan_table.js
@@ -1,4 +1,4 @@
-﻿// priority: 0
+﻿﻿// priority: 0
 "use strict";
 
 function registerTFGArtisanTableRecipes(event) {
@@ -706,12 +706,12 @@ function registerTFGArtisanTableRecipes(event) {
 	event.custom({
 		"result": {"item": "tfg:asphalt_road_stencil_slash_r"},
 		"pattern": [
-			"XXXXXX",
-			"XXXXXX",
-			"XXXXX ",
-			"XXXX  ",
+			"XX  XX",
 			"XXX  X",
-			"XX  XX"
+			"XXXX  ",
+			"XXXXX ",
+			"XXXXXX",
+			"XXXXXX"
 		],
 		"artisanType": "tfg:road_marking_stencil",
 		"type": "tfg:artisan"


### PR DESCRIPTION
## What is the new behavior?
Changed the recipe for the slash_r road stencil.

## Implementation Details
I had to mirror the recipe about the horizontal axis; for the artisan table recipes, they are mirrored about the vertical axis automatically, which means that despite this commit, the previous behavior won't be changed. However, with this change in recipe, the user will be able to craft both slash_r and slash_l using two different recipes.

## Outcome
Fixes #4268