### PR TITLE
fix: update carryon-common to include tfg chests

### DIFF
--- a/config/carryon-common.toml
+++ b/config/carryon-common.toml
@@ -59,7 +59,7 @@
 	#Entities that CAN be picked up (useWhitelistEntities must be true)
 	allowedEntities = ["minecraft:axolotl", "tfc:turkey", "tfc:isopod", "tfc:lobster", "tfc:frog", "tfc:penguin", "tfc:turtle", "tfc:horseshoe_crab", "tfc:crayfish", "tfc:grouse", "tfc:pheasant", "tfc:peafowl", "tfc:rat", "tfc:chicken", "tfc:duck", "tfc:quail", "tfc:rabbit", "tfc:sheep", "tfc:wolf", "tfc:dog", "tfc:pig", "tfc:goat", "tfc:alpaca", "tfc:fox", "tfc:boar", "tfg:wraptor", "tfg:surfer", "tfg:moon_rabbit", "tfg:jerboa", "tfg:mongoose", "tfg:lemming", "species:limpet", "species:birt", "species:stackatick", "species:springling", "tfg:glacian_ram", "wan_ancient_beasts:crusher", "wan_ancient_beasts:glider", "wan_ancient_beasts:soarer", "wan_ancient_beasts:surfer", "wan_ancient_beasts:snatcher", "primitive_creatures:viloger_10", "endermanoverhaul:flower_fields_enderman", "tfg:fox", "tfg:slime"]
 	#Blocks that CAN be picked up (useWhitelistBlocks must be true)
-	allowedBlocks = ["framedblocks:framed_chest", "tfc:wood/chest/*", "tfc:wood/trapped_chest/*", "afc:wood/chest/*", "afc:wood/trapped_chest/*", "#forge:chests/wooden"]
+	allowedBlocks = ["framedblocks:framed_chest", "tfc:wood/chest/*", "tfc:wood/trapped_chest/*", "afc:wood/chest/*", "afc:wood/trapped_chest/*", "tfg:wood/chest/*", "tfg:wood/trapped_chest/*", "#forge:chests/wooden"]
 	#Entities that CAN have other entities stacked on top of them (useWhitelistStacking must be true)
 	allowedStacking = []
 


### PR DESCRIPTION
## What is the new behavior?
The carryon-common file has been updated to accept tfg:wood/chest/* and tfg:/wood/trapped_chest/*, thereby allowing the new TFG wood chests to be picked up.

## Outcome
Fixes: #4260

## Additional Information
The \#forge/chests tag does not seem to work in carryon.