### PR TITLE
Adds shield item models from Vexxed Visuals v1.2.7.1

### DIFF
--- a/kubejs/assets/tfc/models/item/metal/shield/bismuth_bronze.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/bismuth_bronze.json
@@ -1,0 +1,408 @@
+{
+	"credit": "Made with Blockbench",
+	"textures": {
+		"0": "tfc:item/metal/shield/bismuth_bronze",
+		"particle": "tfc:item/metal/shield/bismuth_bronze"
+	},
+	"elements": [
+		{
+			"name": "board",
+			"from": [2, 6, 7],
+			"to": [14, 10, 8],
+			"faces": {
+				"north": {"uv": [0.5, 14, 6.5, 16], "rotation": 180, "texture": "#0"},
+				"east": {"uv": [6, 14, 6.5, 16], "texture": "#0"},
+				"south": {"uv": [0.5, 14, 6.5, 16], "texture": "#0"},
+				"west": {"uv": [0.5, 14, 1, 16], "texture": "#0"},
+				"up": {"uv": [0.5, 14, 6.5, 14.5], "texture": "#0"},
+				"down": {"uv": [0.5, 15.5, 6.5, 16], "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 6, 12],
+			"to": [10, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 6, 12],
+			"to": [6, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 5, 7],
+			"to": [10, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 5, 7],
+			"to": [6, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 10, 7],
+			"to": [10, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 10, 7],
+			"to": [6, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 5, 5],
+			"to": [11, 11, 6],
+			"faces": {
+				"north": {"uv": [2.5, 2.5, 5.5, 5.5], "texture": "#0"},
+				"east": {"uv": [2.5, 2.5, 3, 5.5], "texture": "#0"},
+				"south": {"uv": [10.5, 2.5, 13.5, 5.5], "texture": "#0"},
+				"west": {"uv": [5, 2.5, 5.5, 5.5], "texture": "#0"},
+				"up": {"uv": [2.5, 2.5, 5.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 5, 5.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 3, 6],
+			"to": [13, 13, 7],
+			"faces": {
+				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#0"},
+				"east": {"uv": [1.5, 1.5, 2, 6.5], "texture": "#0"},
+				"south": {"uv": [9.5, 1.5, 14.5, 6.5], "texture": "#0"},
+				"west": {"uv": [6, 1.5, 6.5, 6.5], "texture": "#0"},
+				"up": {"uv": [1.5, 1.5, 6.5, 2], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [1.5, 6, 6.5, 6.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 13, 6],
+			"to": [11, 14, 7],
+			"faces": {
+				"north": {"uv": [2.5, 1, 5.5, 1.5], "texture": "#0"},
+				"east": {"uv": [2.5, 1, 3, 1.5], "texture": "#0"},
+				"south": {"uv": [10.5, 1, 13.5, 1.5], "texture": "#0"},
+				"west": {"uv": [5, 1, 5.5, 1.5], "texture": "#0"},
+				"up": {"uv": [2.5, 1, 5.5, 1.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 1, 5.5, 1.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 14, 7],
+			"to": [11, 15, 8],
+			"faces": {
+				"north": {"uv": [2.5, 0.5, 5.5, 1], "texture": "#0"},
+				"east": {"uv": [2.5, 0.5, 3, 1], "texture": "#0"},
+				"south": {"uv": [10.5, 0.5, 13.5, 1], "texture": "#0"},
+				"west": {"uv": [5, 0.5, 5.5, 1], "texture": "#0"},
+				"up": {"uv": [2.5, 0.5, 5.5, 1], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [10.5, 0.5, 13.5, 1], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 1, 7],
+			"to": [11, 2, 8],
+			"faces": {
+				"north": {"uv": [2.5, 7, 5.5, 7.5], "texture": "#0"},
+				"east": {"uv": [2.5, 7, 3, 7.5], "texture": "#0"},
+				"south": {"uv": [10.5, 7, 13.5, 7.5], "texture": "#0"},
+				"west": {"uv": [5, 7, 5.5, 7.5], "texture": "#0"},
+				"up": {"uv": [10.5, 7, 13.5, 7.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 7, 5.5, 7.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 2, 6],
+			"to": [11, 3, 7],
+			"faces": {
+				"north": {"uv": [2.5, 6.5, 5.5, 7], "texture": "#0"},
+				"east": {"uv": [2.5, 6.5, 3, 7], "texture": "#0"},
+				"south": {"uv": [10.5, 6.5, 13.5, 7], "texture": "#0"},
+				"west": {"uv": [5, 6.5, 5.5, 7], "texture": "#0"},
+				"up": {"uv": [2.5, 6.5, 5.5, 7], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 6.5, 5.5, 7], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 5, 6],
+			"to": [14, 11, 7],
+			"faces": {
+				"north": {"uv": [1, 2.5, 1.5, 5.5], "texture": "#0"},
+				"east": {"uv": [1, 2.5, 1.5, 5.5], "texture": "#0"},
+				"south": {"uv": [14.5, 2.5, 15, 5.5], "texture": "#0"},
+				"west": {"uv": [1, 2.5, 1.5, 5.5], "texture": "#0"},
+				"up": {"uv": [1, 2.5, 1.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [1, 5, 1.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [14, 5, 7],
+			"to": [15, 11, 8],
+			"faces": {
+				"north": {"uv": [0.5, 2.5, 1, 5.5], "texture": "#0"},
+				"east": {"uv": [0.5, 2.5, 1, 5.5], "texture": "#0"},
+				"south": {"uv": [15, 2.5, 15.5, 5.5], "texture": "#0"},
+				"west": {"uv": [15, 2.5, 15.5, 5.5], "texture": "#0"},
+				"up": {"uv": [0.5, 2.5, 1, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [0.5, 5, 1, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 11, 7],
+			"to": [14, 13, 8],
+			"faces": {
+				"north": {"uv": [1, 1.5, 1.5, 2.5], "texture": "#0"},
+				"east": {"uv": [1, 1.5, 1.5, 2.5], "texture": "#0"},
+				"south": {"uv": [14.5, 1.5, 15, 2.5], "texture": "#0"},
+				"west": {"uv": [14.5, 1.5, 15, 2.5], "texture": "#0"},
+				"up": {"uv": [1, 1.5, 1.5, 2], "texture": "#0"},
+				"down": {"uv": [14.5, 2, 15, 2.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 13, 7],
+			"to": [13, 14, 8],
+			"faces": {
+				"north": {"uv": [1.5, 1, 2.5, 1.5], "texture": "#0"},
+				"east": {"uv": [1.5, 1, 2, 1.5], "texture": "#0"},
+				"south": {"uv": [13.5, 1, 14.5, 1.5], "texture": "#0"},
+				"west": {"uv": [13.5, 1, 14, 1.5], "texture": "#0"},
+				"up": {"uv": [1.5, 1, 2.5, 1.5], "texture": "#0"},
+				"down": {"uv": [13.5, 1, 14.5, 1.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 2, 7],
+			"to": [13, 3, 8],
+			"faces": {
+				"north": {"uv": [1.5, 6.5, 2.5, 7], "texture": "#0"},
+				"east": {"uv": [1.5, 6.5, 2, 7], "texture": "#0"},
+				"south": {"uv": [13.5, 6.5, 14.5, 7], "texture": "#0"},
+				"west": {"uv": [13.5, 6.5, 14, 7], "texture": "#0"},
+				"up": {"uv": [13.5, 6.5, 14.5, 7], "texture": "#0"},
+				"down": {"uv": [1.5, 6.5, 2.5, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 13, 7],
+			"to": [5, 14, 8],
+			"faces": {
+				"north": {"uv": [5.5, 1, 6.5, 1.5], "texture": "#0"},
+				"east": {"uv": [10, 1, 10.5, 1.5], "texture": "#0"},
+				"south": {"uv": [9.5, 1, 10.5, 1.5], "texture": "#0"},
+				"west": {"uv": [6, 1, 6.5, 1.5], "texture": "#0"},
+				"up": {"uv": [5.5, 1, 6.5, 1.5], "texture": "#0"},
+				"down": {"uv": [9.5, 1, 10.5, 1.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 2, 7],
+			"to": [5, 3, 8],
+			"faces": {
+				"north": {"uv": [5.5, 6.5, 6.5, 7], "texture": "#0"},
+				"east": {"uv": [10, 6.5, 10.5, 7], "texture": "#0"},
+				"south": {"uv": [9.5, 6.5, 10.5, 7], "texture": "#0"},
+				"west": {"uv": [6, 6.5, 6.5, 7], "texture": "#0"},
+				"up": {"uv": [9.5, 6.5, 10.5, 7], "texture": "#0"},
+				"down": {"uv": [5.5, 6.5, 6.5, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 3, 7],
+			"to": [14, 5, 8],
+			"faces": {
+				"north": {"uv": [1, 5.5, 1.5, 6.5], "texture": "#0"},
+				"east": {"uv": [1, 5.5, 1.5, 6.5], "texture": "#0"},
+				"south": {"uv": [14.5, 5.5, 15, 6.5], "texture": "#0"},
+				"west": {"uv": [14.5, 5.5, 15, 6.5], "texture": "#0"},
+				"up": {"uv": [1, 5.5, 1.5, 6], "texture": "#0"},
+				"down": {"uv": [14.5, 6, 15, 6.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 11, 7],
+			"to": [3, 13, 8],
+			"faces": {
+				"north": {"uv": [6.5, 1.5, 7, 2.5], "texture": "#0"},
+				"east": {"uv": [9, 1.5, 9.5, 2.5], "texture": "#0"},
+				"south": {"uv": [9, 1.5, 9.5, 2.5], "texture": "#0"},
+				"west": {"uv": [6.5, 1.5, 7, 2.5], "texture": "#0"},
+				"up": {"uv": [6.5, 1.5, 7, 2], "texture": "#0"},
+				"down": {"uv": [9, 2, 9.5, 2.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 3, 7],
+			"to": [3, 5, 8],
+			"faces": {
+				"north": {"uv": [6.5, 5.5, 7, 6.5], "texture": "#0"},
+				"east": {"uv": [9, 5.5, 9.5, 6.5], "texture": "#0"},
+				"south": {"uv": [9, 5.5, 9.5, 6.5], "texture": "#0"},
+				"west": {"uv": [6.5, 5.5, 7, 6.5], "texture": "#0"},
+				"up": {"uv": [9, 5.5, 9.5, 6], "texture": "#0"},
+				"down": {"uv": [6.5, 6, 7, 6.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [1, 5, 7],
+			"to": [2, 11, 8],
+			"faces": {
+				"north": {"uv": [7, 2.5, 7.5, 5.5], "texture": "#0"},
+				"east": {"uv": [8.5, 2.5, 9, 5.5], "texture": "#0"},
+				"south": {"uv": [8.5, 2.5, 9, 5.5], "texture": "#0"},
+				"west": {"uv": [7, 2.5, 7.5, 5.5], "texture": "#0"},
+				"up": {"uv": [7, 2.5, 7.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [7, 5, 7.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 5, 6],
+			"to": [3, 11, 7],
+			"faces": {
+				"north": {"uv": [6.5, 2.5, 7, 5.5], "texture": "#0"},
+				"east": {"uv": [6.5, 2.5, 7, 5.5], "texture": "#0"},
+				"south": {"uv": [9, 2.5, 9.5, 5.5], "texture": "#0"},
+				"west": {"uv": [6.5, 2.5, 7, 5.5], "texture": "#0"},
+				"up": {"uv": [6.5, 2.5, 7, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [6.5, 5, 7, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 5, 5],
+			"to": [12, 11, 6],
+			"faces": {
+				"north": {"uv": [2, 2.5, 2.5, 5.5], "texture": "#0"},
+				"east": {"uv": [2, 2.5, 2.5, 5.5], "texture": "#0"},
+				"south": {"uv": [13.5, 2.5, 14, 5.5], "texture": "#0"},
+				"west": {"uv": [2, 2.5, 2.5, 5.5], "texture": "#0"},
+				"up": {"uv": [2, 2.5, 2.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2, 5, 2.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [4, 5, 5],
+			"to": [5, 11, 6],
+			"faces": {
+				"north": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"east": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"south": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"west": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"up": {"uv": [5.5, 2.5, 6, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [5.5, 5, 6, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 11, 5],
+			"to": [11, 12, 6],
+			"faces": {
+				"north": {"uv": [2.5, 2, 5.5, 2.5], "texture": "#0"},
+				"east": {"uv": [2.5, 2, 3, 2.5], "texture": "#0"},
+				"south": {"uv": [10.5, 2, 13.5, 2.5], "texture": "#0"},
+				"west": {"uv": [5, 2, 5.5, 2.5], "texture": "#0"},
+				"up": {"uv": [2.5, 2, 5.5, 2.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 2, 5.5, 2.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 4, 5],
+			"to": [11, 5, 6],
+			"faces": {
+				"north": {"uv": [2.5, 5.5, 5.5, 6], "texture": "#0"},
+				"east": {"uv": [2.5, 5.5, 3, 6], "texture": "#0"},
+				"south": {"uv": [2.5, 5.5, 5.5, 6], "texture": "#0"},
+				"west": {"uv": [5, 5.5, 5.5, 6], "texture": "#0"},
+				"up": {"uv": [2.5, 5.5, 5.5, 6], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 5.5, 5.5, 6], "rotation": 180, "texture": "#0"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"ground": {
+			"translation": [0, 3, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.25, 0.25, 0],
+			"scale": [0.65, 0.65, 0.65]
+		},
+		"head": {
+			"rotation": [90, 0, 0],
+			"translation": [0, 5.5, -0.5],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 0, 0],
+			"scale": [0.75, 0.75, 0.75]
+		}
+	},
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6]
+		}, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28
+	],
+	"overrides": [{
+		"predicate": { "blocking": 1 },
+		"model": "tfc:item/metal/shield/bismuth_bronze_blocking"
+		}
+	]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/bismuth_bronze_blocking.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/bismuth_bronze_blocking.json
@@ -1,0 +1,51 @@
+{
+	"credit": "Made with Blockbench",
+	"parent":"tfc:item/metal/shield/bismuth_bronze",
+	"textures": {
+		"0": "tfc:item/metal/shield/bismuth_bronze",
+		"particle": "tfc:item/metal/shield/bismuth_bronze"
+	},
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"firstperson_lefthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"ground": {
+			"translation": [0, 2, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.25, 0.25, 0],
+			"scale": [0.65, 0.65, 0.65]
+		},
+		"head": {
+			"rotation": [90, 0, 0],
+			"translation": [0, 5.5, -0.5],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 0, -2.13],
+			"scale": [2.02, 2.02, 2.02]
+		}
+	},
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6]
+		}, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28
+	]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/black_bronze.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/black_bronze.json
@@ -1,0 +1,408 @@
+{
+	"credit": "Made with Blockbench",
+	"textures": {
+		"0": "tfc:item/metal/shield/black_bronze",
+		"particle": "tfc:item/metal/shield/black_bronze"
+	},
+	"elements": [
+		{
+			"name": "board",
+			"from": [2, 6, 7],
+			"to": [14, 10, 8],
+			"faces": {
+				"north": {"uv": [0.5, 14, 6.5, 16], "rotation": 180, "texture": "#0"},
+				"east": {"uv": [6, 14, 6.5, 16], "texture": "#0"},
+				"south": {"uv": [0.5, 14, 6.5, 16], "texture": "#0"},
+				"west": {"uv": [0.5, 14, 1, 16], "texture": "#0"},
+				"up": {"uv": [0.5, 14, 6.5, 14.5], "texture": "#0"},
+				"down": {"uv": [0.5, 15.5, 6.5, 16], "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 6, 12],
+			"to": [10, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 6, 12],
+			"to": [6, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 5, 7],
+			"to": [10, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 5, 7],
+			"to": [6, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 10, 7],
+			"to": [10, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 10, 7],
+			"to": [6, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 5, 5],
+			"to": [11, 11, 6],
+			"faces": {
+				"north": {"uv": [2.5, 2.5, 5.5, 5.5], "texture": "#0"},
+				"east": {"uv": [2.5, 2.5, 3, 5.5], "texture": "#0"},
+				"south": {"uv": [10.5, 2.5, 13.5, 5.5], "texture": "#0"},
+				"west": {"uv": [5, 2.5, 5.5, 5.5], "texture": "#0"},
+				"up": {"uv": [2.5, 2.5, 5.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 5, 5.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 3, 6],
+			"to": [13, 13, 7],
+			"faces": {
+				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#0"},
+				"east": {"uv": [1.5, 1.5, 2, 6.5], "texture": "#0"},
+				"south": {"uv": [9.5, 1.5, 14.5, 6.5], "texture": "#0"},
+				"west": {"uv": [6, 1.5, 6.5, 6.5], "texture": "#0"},
+				"up": {"uv": [1.5, 1.5, 6.5, 2], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [1.5, 6, 6.5, 6.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 13, 6],
+			"to": [11, 14, 7],
+			"faces": {
+				"north": {"uv": [2.5, 1, 5.5, 1.5], "texture": "#0"},
+				"east": {"uv": [2.5, 1, 3, 1.5], "texture": "#0"},
+				"south": {"uv": [10.5, 1, 13.5, 1.5], "texture": "#0"},
+				"west": {"uv": [5, 1, 5.5, 1.5], "texture": "#0"},
+				"up": {"uv": [2.5, 1, 5.5, 1.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 1, 5.5, 1.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 14, 7],
+			"to": [11, 15, 8],
+			"faces": {
+				"north": {"uv": [2.5, 0.5, 5.5, 1], "texture": "#0"},
+				"east": {"uv": [2.5, 0.5, 3, 1], "texture": "#0"},
+				"south": {"uv": [10.5, 0.5, 13.5, 1], "texture": "#0"},
+				"west": {"uv": [5, 0.5, 5.5, 1], "texture": "#0"},
+				"up": {"uv": [2.5, 0.5, 5.5, 1], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [10.5, 0.5, 13.5, 1], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 1, 7],
+			"to": [11, 2, 8],
+			"faces": {
+				"north": {"uv": [2.5, 7, 5.5, 7.5], "texture": "#0"},
+				"east": {"uv": [2.5, 7, 3, 7.5], "texture": "#0"},
+				"south": {"uv": [10.5, 7, 13.5, 7.5], "texture": "#0"},
+				"west": {"uv": [5, 7, 5.5, 7.5], "texture": "#0"},
+				"up": {"uv": [10.5, 7, 13.5, 7.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 7, 5.5, 7.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 2, 6],
+			"to": [11, 3, 7],
+			"faces": {
+				"north": {"uv": [2.5, 6.5, 5.5, 7], "texture": "#0"},
+				"east": {"uv": [2.5, 6.5, 3, 7], "texture": "#0"},
+				"south": {"uv": [10.5, 6.5, 13.5, 7], "texture": "#0"},
+				"west": {"uv": [5, 6.5, 5.5, 7], "texture": "#0"},
+				"up": {"uv": [2.5, 6.5, 5.5, 7], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 6.5, 5.5, 7], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 5, 6],
+			"to": [14, 11, 7],
+			"faces": {
+				"north": {"uv": [1, 2.5, 1.5, 5.5], "texture": "#0"},
+				"east": {"uv": [1, 2.5, 1.5, 5.5], "texture": "#0"},
+				"south": {"uv": [14.5, 2.5, 15, 5.5], "texture": "#0"},
+				"west": {"uv": [1, 2.5, 1.5, 5.5], "texture": "#0"},
+				"up": {"uv": [1, 2.5, 1.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [1, 5, 1.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [14, 5, 7],
+			"to": [15, 11, 8],
+			"faces": {
+				"north": {"uv": [0.5, 2.5, 1, 5.5], "texture": "#0"},
+				"east": {"uv": [0.5, 2.5, 1, 5.5], "texture": "#0"},
+				"south": {"uv": [15, 2.5, 15.5, 5.5], "texture": "#0"},
+				"west": {"uv": [15, 2.5, 15.5, 5.5], "texture": "#0"},
+				"up": {"uv": [0.5, 2.5, 1, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [0.5, 5, 1, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 11, 7],
+			"to": [14, 13, 8],
+			"faces": {
+				"north": {"uv": [1, 1.5, 1.5, 2.5], "texture": "#0"},
+				"east": {"uv": [1, 1.5, 1.5, 2.5], "texture": "#0"},
+				"south": {"uv": [14.5, 1.5, 15, 2.5], "texture": "#0"},
+				"west": {"uv": [14.5, 1.5, 15, 2.5], "texture": "#0"},
+				"up": {"uv": [1, 1.5, 1.5, 2], "texture": "#0"},
+				"down": {"uv": [14.5, 2, 15, 2.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 13, 7],
+			"to": [13, 14, 8],
+			"faces": {
+				"north": {"uv": [1.5, 1, 2.5, 1.5], "texture": "#0"},
+				"east": {"uv": [1.5, 1, 2, 1.5], "texture": "#0"},
+				"south": {"uv": [13.5, 1, 14.5, 1.5], "texture": "#0"},
+				"west": {"uv": [13.5, 1, 14, 1.5], "texture": "#0"},
+				"up": {"uv": [1.5, 1, 2.5, 1.5], "texture": "#0"},
+				"down": {"uv": [13.5, 1, 14.5, 1.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 2, 7],
+			"to": [13, 3, 8],
+			"faces": {
+				"north": {"uv": [1.5, 6.5, 2.5, 7], "texture": "#0"},
+				"east": {"uv": [1.5, 6.5, 2, 7], "texture": "#0"},
+				"south": {"uv": [13.5, 6.5, 14.5, 7], "texture": "#0"},
+				"west": {"uv": [13.5, 6.5, 14, 7], "texture": "#0"},
+				"up": {"uv": [13.5, 6.5, 14.5, 7], "texture": "#0"},
+				"down": {"uv": [1.5, 6.5, 2.5, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 13, 7],
+			"to": [5, 14, 8],
+			"faces": {
+				"north": {"uv": [5.5, 1, 6.5, 1.5], "texture": "#0"},
+				"east": {"uv": [10, 1, 10.5, 1.5], "texture": "#0"},
+				"south": {"uv": [9.5, 1, 10.5, 1.5], "texture": "#0"},
+				"west": {"uv": [6, 1, 6.5, 1.5], "texture": "#0"},
+				"up": {"uv": [5.5, 1, 6.5, 1.5], "texture": "#0"},
+				"down": {"uv": [9.5, 1, 10.5, 1.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 2, 7],
+			"to": [5, 3, 8],
+			"faces": {
+				"north": {"uv": [5.5, 6.5, 6.5, 7], "texture": "#0"},
+				"east": {"uv": [10, 6.5, 10.5, 7], "texture": "#0"},
+				"south": {"uv": [9.5, 6.5, 10.5, 7], "texture": "#0"},
+				"west": {"uv": [6, 6.5, 6.5, 7], "texture": "#0"},
+				"up": {"uv": [9.5, 6.5, 10.5, 7], "texture": "#0"},
+				"down": {"uv": [5.5, 6.5, 6.5, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 3, 7],
+			"to": [14, 5, 8],
+			"faces": {
+				"north": {"uv": [1, 5.5, 1.5, 6.5], "texture": "#0"},
+				"east": {"uv": [1, 5.5, 1.5, 6.5], "texture": "#0"},
+				"south": {"uv": [14.5, 5.5, 15, 6.5], "texture": "#0"},
+				"west": {"uv": [14.5, 5.5, 15, 6.5], "texture": "#0"},
+				"up": {"uv": [1, 5.5, 1.5, 6], "texture": "#0"},
+				"down": {"uv": [14.5, 6, 15, 6.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 11, 7],
+			"to": [3, 13, 8],
+			"faces": {
+				"north": {"uv": [6.5, 1.5, 7, 2.5], "texture": "#0"},
+				"east": {"uv": [9, 1.5, 9.5, 2.5], "texture": "#0"},
+				"south": {"uv": [9, 1.5, 9.5, 2.5], "texture": "#0"},
+				"west": {"uv": [6.5, 1.5, 7, 2.5], "texture": "#0"},
+				"up": {"uv": [6.5, 1.5, 7, 2], "texture": "#0"},
+				"down": {"uv": [9, 2, 9.5, 2.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 3, 7],
+			"to": [3, 5, 8],
+			"faces": {
+				"north": {"uv": [6.5, 5.5, 7, 6.5], "texture": "#0"},
+				"east": {"uv": [9, 5.5, 9.5, 6.5], "texture": "#0"},
+				"south": {"uv": [9, 5.5, 9.5, 6.5], "texture": "#0"},
+				"west": {"uv": [6.5, 5.5, 7, 6.5], "texture": "#0"},
+				"up": {"uv": [9, 5.5, 9.5, 6], "texture": "#0"},
+				"down": {"uv": [6.5, 6, 7, 6.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [1, 5, 7],
+			"to": [2, 11, 8],
+			"faces": {
+				"north": {"uv": [7, 2.5, 7.5, 5.5], "texture": "#0"},
+				"east": {"uv": [8.5, 2.5, 9, 5.5], "texture": "#0"},
+				"south": {"uv": [8.5, 2.5, 9, 5.5], "texture": "#0"},
+				"west": {"uv": [7, 2.5, 7.5, 5.5], "texture": "#0"},
+				"up": {"uv": [7, 2.5, 7.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [7, 5, 7.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 5, 6],
+			"to": [3, 11, 7],
+			"faces": {
+				"north": {"uv": [6.5, 2.5, 7, 5.5], "texture": "#0"},
+				"east": {"uv": [6.5, 2.5, 7, 5.5], "texture": "#0"},
+				"south": {"uv": [9, 2.5, 9.5, 5.5], "texture": "#0"},
+				"west": {"uv": [6.5, 2.5, 7, 5.5], "texture": "#0"},
+				"up": {"uv": [6.5, 2.5, 7, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [6.5, 5, 7, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 5, 5],
+			"to": [12, 11, 6],
+			"faces": {
+				"north": {"uv": [2, 2.5, 2.5, 5.5], "texture": "#0"},
+				"east": {"uv": [2, 2.5, 2.5, 5.5], "texture": "#0"},
+				"south": {"uv": [13.5, 2.5, 14, 5.5], "texture": "#0"},
+				"west": {"uv": [2, 2.5, 2.5, 5.5], "texture": "#0"},
+				"up": {"uv": [2, 2.5, 2.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2, 5, 2.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [4, 5, 5],
+			"to": [5, 11, 6],
+			"faces": {
+				"north": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"east": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"south": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"west": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"up": {"uv": [5.5, 2.5, 6, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [5.5, 5, 6, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 11, 5],
+			"to": [11, 12, 6],
+			"faces": {
+				"north": {"uv": [2.5, 2, 5.5, 2.5], "texture": "#0"},
+				"east": {"uv": [2.5, 2, 3, 2.5], "texture": "#0"},
+				"south": {"uv": [10.5, 2, 13.5, 2.5], "texture": "#0"},
+				"west": {"uv": [5, 2, 5.5, 2.5], "texture": "#0"},
+				"up": {"uv": [2.5, 2, 5.5, 2.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 2, 5.5, 2.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 4, 5],
+			"to": [11, 5, 6],
+			"faces": {
+				"north": {"uv": [2.5, 5.5, 5.5, 6], "texture": "#0"},
+				"east": {"uv": [2.5, 5.5, 3, 6], "texture": "#0"},
+				"south": {"uv": [2.5, 5.5, 5.5, 6], "texture": "#0"},
+				"west": {"uv": [5, 5.5, 5.5, 6], "texture": "#0"},
+				"up": {"uv": [2.5, 5.5, 5.5, 6], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 5.5, 5.5, 6], "rotation": 180, "texture": "#0"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"ground": {
+			"translation": [0, 3, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.25, 0.25, 0],
+			"scale": [0.65, 0.65, 0.65]
+		},
+		"head": {
+			"rotation": [90, 0, 0],
+			"translation": [0, 5.5, -0.5],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 0, 0],
+			"scale": [0.75, 0.75, 0.75]
+		}
+	},
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6]
+		}, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28
+	],
+	"overrides": [{
+		"predicate": { "blocking": 1 },
+		"model": "tfc:item/metal/shield/black_bronze_blocking"
+		}
+	]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/black_bronze_blocking.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/black_bronze_blocking.json
@@ -1,0 +1,51 @@
+{
+	"credit": "Made with Blockbench",
+	"parent":"tfc:item/metal/shield/black_bronze",
+	"textures": {
+		"0": "tfc:item/metal/shield/black_bronze",
+		"particle": "tfc:item/metal/shield/black_bronze"
+	},
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"firstperson_lefthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"ground": {
+			"translation": [0, 2, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.25, 0.25, 0],
+			"scale": [0.65, 0.65, 0.65]
+		},
+		"head": {
+			"rotation": [90, 0, 0],
+			"translation": [0, 5.5, -0.5],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 0, -2.13],
+			"scale": [2.02, 2.02, 2.02]
+		}
+	},
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6]
+		}, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28
+	]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/black_steel.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/black_steel.json
@@ -1,0 +1,394 @@
+{
+	"credit": "Made with Blockbench",
+	"textures": {
+		"0": "tfc:item/metal/shield/black_steel",
+		"particle": "tfc:item/metal/shield/black_steel"
+	},
+	"elements": [
+		{
+			"name": "handle",
+			"from": [9, 6, 12],
+			"to": [10, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 6, 12],
+			"to": [6, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 5, 7],
+			"to": [10, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 5, 7],
+			"to": [6, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 10, 7],
+			"to": [10, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 10, 7],
+			"to": [6, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 6, 7],
+			"to": [14, 10, 8],
+			"faces": {
+				"north": {"uv": [0.5, 13.5, 6.5, 15.5], "texture": "#0"},
+				"east": {"uv": [6, 13.5, 6.5, 15.5], "texture": "#0"},
+				"south": {"uv": [0.5, 13.5, 6.5, 15.5], "texture": "#0"},
+				"west": {"uv": [0.5, 13.5, 1, 15.5], "texture": "#0"},
+				"up": {"uv": [0.5, 13.5, 6.5, 14], "texture": "#0"},
+				"down": {"uv": [0.5, 15, 6.5, 15.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, -8, 6],
+			"to": [5, 18, 7],
+			"faces": {
+				"north": {"uv": [5.5, 0, 7, 13], "texture": "#0"},
+				"east": {"uv": [10, 0, 10.5, 13], "texture": "#0"},
+				"south": {"uv": [9, 0, 10.5, 13], "texture": "#0"},
+				"west": {"uv": [6.5, 0, 7, 13], "texture": "#0"},
+				"up": {"uv": [13.5, 0, 15, 0.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [13.5, 12.5, 15, 13], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, -8, 6],
+			"to": [14, 18, 7],
+			"faces": {
+				"north": {"uv": [1, 0, 2.5, 13], "texture": "#0"},
+				"east": {"uv": [1, 0, 1.5, 13], "texture": "#0"},
+				"south": {"uv": [13.5, 0, 15, 13], "texture": "#0"},
+				"west": {"uv": [13.5, 0, 14, 13], "texture": "#0"},
+				"up": {"uv": [9, 0, 10.5, 0.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [9, 12.5, 10.5, 13], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, -8, 5],
+			"to": [14, -4, 6],
+			"faces": {
+				"north": {"uv": [1, 11, 2.5, 13], "texture": "#0"},
+				"east": {"uv": [1, 11, 1.5, 13], "texture": "#0"},
+				"south": {"uv": [13.5, 11, 15, 13], "texture": "#0"},
+				"west": {"uv": [13.5, 11, 14, 13], "texture": "#0"},
+				"up": {"uv": [1, 11, 2.5, 11.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [1, 12.5, 2.5, 13], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 3, 5],
+			"to": [14, 7, 6],
+			"faces": {
+				"north": {"uv": [1, 5.5, 2.5, 7.5], "texture": "#0"},
+				"east": {"uv": [1, 5.5, 1.5, 7.5], "texture": "#0"},
+				"south": {"uv": [13.5, 5.5, 15, 7.5], "texture": "#0"},
+				"west": {"uv": [13.5, 5.5, 14, 7.5], "texture": "#0"},
+				"up": {"uv": [1, 5.5, 2.5, 6], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [1, 7, 2.5, 7.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, -8, 5],
+			"to": [5, -4, 6],
+			"faces": {
+				"north": {"uv": [5.5, 11, 7, 13], "texture": "#0"},
+				"east": {"uv": [5.5, 11, 6, 13], "texture": "#0"},
+				"south": {"uv": [9, 11, 10.5, 13], "texture": "#0"},
+				"west": {"uv": [6.5, 11, 7, 13], "texture": "#0"},
+				"up": {"uv": [5.5, 11, 7, 11.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [5.5, 12.5, 7, 13], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 3, 5],
+			"to": [5, 7, 6],
+			"faces": {
+				"north": {"uv": [5.5, 5.5, 7, 7.5], "texture": "#0"},
+				"east": {"uv": [5.5, 5.5, 6, 7.5], "texture": "#0"},
+				"south": {"uv": [9, 5.5, 10.5, 7.5], "texture": "#0"},
+				"west": {"uv": [6.5, 5.5, 7, 7.5], "texture": "#0"},
+				"up": {"uv": [5.5, 5.5, 7, 6], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [5.5, 7, 7, 7.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 14, 5],
+			"to": [14, 18, 6],
+			"faces": {
+				"north": {"uv": [1, 0, 2.5, 2], "texture": "#0"},
+				"east": {"uv": [1, 0, 1.5, 2], "texture": "#0"},
+				"south": {"uv": [13.5, 0, 15, 2], "texture": "#0"},
+				"west": {"uv": [13.5, 0, 14, 2], "texture": "#0"},
+				"up": {"uv": [1, 0, 2.5, 0.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [1, 1.5, 2.5, 2], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 14, 5],
+			"to": [5, 18, 6],
+			"faces": {
+				"north": {"uv": [5.5, 0, 7, 2], "texture": "#0"},
+				"east": {"uv": [5.5, 0, 6, 2], "texture": "#0"},
+				"south": {"uv": [9, 0, 10.5, 2], "texture": "#0"},
+				"west": {"uv": [6.5, 0, 7, 2], "texture": "#0"},
+				"up": {"uv": [5.5, 0, 7, 0.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [5.5, 1.5, 7, 2], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, -8, 5],
+			"to": [11, 18, 6],
+			"faces": {
+				"north": {"uv": [2.5, 0, 5.5, 13], "texture": "#0"},
+				"east": {"uv": [2.5, 0, 3, 13], "texture": "#0"},
+				"south": {"uv": [10.5, 0, 13.5, 13], "texture": "#0"},
+				"west": {"uv": [5, 0, 5.5, 13], "texture": "#0"},
+				"up": {"uv": [10.5, 0, 13.5, 0.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [10.5, 12.5, 13.5, 13], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, -8, 4],
+			"to": [11, -4, 5],
+			"faces": {
+				"north": {"uv": [2.5, 11, 5.5, 13], "texture": "#0"},
+				"east": {"uv": [2.5, 11, 3, 13], "texture": "#0"},
+				"south": {"uv": [10.5, 11, 13.5, 13], "texture": "#0"},
+				"west": {"uv": [5, 11, 5.5, 13], "texture": "#0"},
+				"up": {"uv": [2.5, 11, 5.5, 11.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 12.5, 5.5, 13], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 3, 4],
+			"to": [11, 7, 5],
+			"faces": {
+				"north": {"uv": [2.5, 5.5, 5.5, 7.5], "texture": "#0"},
+				"east": {"uv": [2.5, 5.5, 3, 7.5], "texture": "#0"},
+				"south": {"uv": [10.5, 5.5, 13.5, 7.5], "texture": "#0"},
+				"west": {"uv": [5, 5.5, 5.5, 7.5], "texture": "#0"},
+				"up": {"uv": [2.5, 5.5, 5.5, 6], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 7, 5.5, 7.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 14, 4],
+			"to": [11, 18, 5],
+			"faces": {
+				"north": {"uv": [2.5, 0, 5.5, 2], "texture": "#0"},
+				"east": {"uv": [2.5, 0, 3, 2], "texture": "#0"},
+				"south": {"uv": [10.5, 0, 13.5, 2], "texture": "#0"},
+				"west": {"uv": [5, 0, 5.5, 2], "texture": "#0"},
+				"up": {"uv": [2.5, 0, 5.5, 0.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 1.5, 5.5, 2], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 5, 6],
+			"to": [11, 11, 7],
+			"faces": {
+				"north": {"uv": [2, 13, 5, 16], "texture": "#0"},
+				"east": {"uv": [4.5, 13, 5, 16], "texture": "#0"},
+				"south": {"uv": [2, 13, 5, 16], "texture": "#0"},
+				"west": {"uv": [2, 13, 2.5, 16], "texture": "#0"},
+				"up": {"uv": [2, 13, 5, 13.5], "texture": "#0"},
+				"down": {"uv": [2, 15.5, 5, 16], "texture": "#0"}
+			}
+		},
+		{
+			"from": [0, -8, 7],
+			"to": [2, 18, 8],
+			"faces": {
+				"north": {"uv": [7, 0, 8, 13], "texture": "#0"},
+				"east": {"uv": [8.5, 0, 9, 13], "texture": "#0"},
+				"south": {"uv": [8, 0, 9, 13], "texture": "#0"},
+				"west": {"uv": [7.5, 0, 8, 13], "texture": "#0"},
+				"up": {"uv": [15, 0, 16, 0.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [15, 12.5, 16, 13], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [14, -8, 7],
+			"to": [16, 18, 8],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 13], "texture": "#0"},
+				"east": {"uv": [0, 0, 0.5, 13], "texture": "#0"},
+				"south": {"uv": [15, 0, 16, 13], "texture": "#0"},
+				"west": {"uv": [15, 0, 15.5, 13], "texture": "#0"},
+				"up": {"uv": [8, 0, 9, 0.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [8, 12.5, 9, 13], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [14, 14, 6],
+			"to": [16, 18, 7],
+			"faces": {
+				"north": {"uv": [0, 0, 1, 2], "texture": "#0"},
+				"east": {"uv": [0, 0, 0.5, 2], "texture": "#0"},
+				"south": {"uv": [15, 0, 16, 2], "texture": "#0"},
+				"west": {"uv": [15, 0, 15.5, 2], "texture": "#0"},
+				"up": {"uv": [0, 0, 1, 0.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [0, 1.5, 1, 2], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [14, -8, 6],
+			"to": [16, -4, 7],
+			"faces": {
+				"north": {"uv": [0, 11, 1, 13], "texture": "#0"},
+				"east": {"uv": [0, 11, 0.5, 13], "texture": "#0"},
+				"south": {"uv": [15, 11, 16, 13], "texture": "#0"},
+				"west": {"uv": [15, 11, 15.5, 13], "texture": "#0"},
+				"up": {"uv": [0, 11, 1, 11.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [0, 12.5, 1, 13], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [14, 3, 6],
+			"to": [16, 7, 7],
+			"faces": {
+				"north": {"uv": [0, 5.5, 1, 7.5], "texture": "#0"},
+				"east": {"uv": [0, 5.5, 0.5, 7.5], "texture": "#0"},
+				"south": {"uv": [15, 5.5, 16, 7.5], "texture": "#0"},
+				"west": {"uv": [15, 5.5, 15.5, 7.5], "texture": "#0"},
+				"up": {"uv": [0, 5.5, 1, 6], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [0, 7, 1, 7.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [0, -8, 6],
+			"to": [2, -4, 7],
+			"faces": {
+				"north": {"uv": [7, 11, 8, 13], "texture": "#0"},
+				"east": {"uv": [7, 11, 7.5, 13], "texture": "#0"},
+				"south": {"uv": [8, 11, 9, 13], "texture": "#0"},
+				"west": {"uv": [7.5, 11, 8, 13], "texture": "#0"},
+				"up": {"uv": [7, 11, 8, 11.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [7, 12.5, 8, 13], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [0, 3, 6],
+			"to": [2, 7, 7],
+			"faces": {
+				"north": {"uv": [7, 5.5, 8, 7.5], "texture": "#0"},
+				"east": {"uv": [7, 5.5, 7.5, 7.5], "texture": "#0"},
+				"south": {"uv": [8, 5.5, 9, 7.5], "texture": "#0"},
+				"west": {"uv": [7.5, 5.5, 8, 7.5], "texture": "#0"},
+				"up": {"uv": [7, 5.5, 8, 6], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [7, 7, 8, 7.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [0, 14, 6],
+			"to": [2, 18, 7],
+			"faces": {
+				"north": {"uv": [7, 0, 8, 2], "texture": "#0"},
+				"east": {"uv": [7, 0, 7.5, 2], "texture": "#0"},
+				"south": {"uv": [8, 0, 9, 2], "texture": "#0"},
+				"west": {"uv": [7.5, 0, 8, 2], "texture": "#0"},
+				"up": {"uv": [7, 0, 8, 0.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [7, 1.5, 8, 2], "rotation": 180, "texture": "#0"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"ground": {
+			"translation": [0, 3, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.5, 1.5, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"head": {
+			"rotation": [90, 0, -180],
+			"translation": [0, 4.25, -1.31],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 1.4, 0],
+			"scale": [0.6, 0.6, 0.6]
+		}
+	},
+	"overrides": [{
+		"predicate": { "blocking": 1 },
+		"model": "tfc:item/metal/shield/black_steel_blocking"
+		}
+	],
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6]
+		}, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/black_steel_blocking.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/black_steel_blocking.json
@@ -1,0 +1,50 @@
+{
+	"credit": "Made with Blockbench",
+	"parent":"tfc:item/metal/shield/black_steel",
+	"textures": {
+		"0": "tfc:item/metal/shield/black_steel",
+		"particle": "tfc:item/metal/shield/black_steel"
+	},
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"firstperson_lefthand": {
+			"rotation": [3, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"ground": {
+			"translation": [0, 1, 0],
+			"scale": [0.3, 0.3, 0.3]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.5, 1.5, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"head": {
+			"rotation": [90, 0, -180],
+			"translation": [0, 4.25, -1.31],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 5.5, -0.38],
+			"scale": [2.02, 2.02, 2.02]
+		}
+	},
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6]
+		}, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/blue_steel.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/blue_steel.json
@@ -1,0 +1,405 @@
+{
+	"credit": "Made with Blockbench",
+	"textures": {
+		"0": "tfc:item/metal/shield/blue_steel",
+		"particle": "tfc:item/metal/shield/blue_steel"
+	},
+	"elements": [
+		{
+			"name": "handle",
+			"from": [9, 6, 12],
+			"to": [10, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 6, 12],
+			"to": [6, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 5, 7],
+			"to": [10, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 5, 7],
+			"to": [6, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 10, 7],
+			"to": [10, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 10, 7],
+			"to": [6, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 6, 7],
+			"to": [13, 10, 8],
+			"faces": {
+				"north": {"uv": [0.5, 14, 6.5, 16], "texture": "#0"},
+				"east": {"uv": [0.5, 14, 1, 16], "texture": "#0"},
+				"south": {"uv": [0.5, 14, 6.5, 16], "texture": "#0"},
+				"west": {"uv": [6, 14, 6.5, 16], "texture": "#0"},
+				"up": {"uv": [0.5, 14, 6.5, 14.5], "texture": "#0"},
+				"down": {"uv": [0.5, 15.5, 6.5, 16], "texture": "#0"}
+			}
+		},
+		{
+			"from": [6, 5, 6],
+			"to": [10, 11, 7],
+			"faces": {
+				"north": {"uv": [2, 14, 4, 16], "texture": "#0"},
+				"east": {"uv": [3.5, 14, 4, 16], "texture": "#0"},
+				"south": {"uv": [2, 14, 4, 16], "texture": "#0"},
+				"west": {"uv": [2, 14, 2.5, 16], "texture": "#0"},
+				"up": {"uv": [2, 14, 4, 14.5], "texture": "#0"},
+				"down": {"uv": [2, 15.5, 4, 16], "texture": "#0"}
+			}
+		},
+		{
+			"from": [7, -6, 5],
+			"to": [9, 4, 6],
+			"faces": {
+				"north": {"uv": [3.5, 7.5, 4.5, 12.5], "texture": "#0"},
+				"east": {"uv": [3.5, 7.5, 4, 12.5], "texture": "#0"},
+				"south": {"uv": [11.5, 7.5, 12.5, 12.5], "texture": "#0"},
+				"west": {"uv": [4, 7.5, 4.5, 12.5], "texture": "#0"},
+				"up": {"uv": [3.5, 7.5, 4.5, 8], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [3.5, 12, 4.5, 12.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [7, 9, 5],
+			"to": [9, 19, 6],
+			"faces": {
+				"north": {"uv": [3.5, 0, 4.5, 5], "texture": "#0"},
+				"east": {"uv": [3.5, 0, 4, 5], "texture": "#0"},
+				"south": {"uv": [11.5, 0, 12.5, 5], "texture": "#0"},
+				"west": {"uv": [4, 0, 4.5, 5], "texture": "#0"},
+				"up": {"uv": [3.5, 0, 4.5, 0.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [3.5, 4.5, 4.5, 5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [6, -5, 5],
+			"to": [7, 4, 6],
+			"faces": {
+				"north": {"uv": [4.5, 7.5, 5, 12], "texture": "#0"},
+				"east": {"uv": [11, 7.5, 11.5, 12], "texture": "#0"},
+				"south": {"uv": [11, 7.5, 11.5, 12], "texture": "#0"},
+				"west": {"uv": [4.5, 7.5, 5, 12], "texture": "#0"},
+				"up": {"uv": [4.5, 7.5, 5, 8], "texture": "#0"},
+				"down": {"uv": [4.5, 11.5, 5, 12], "texture": "#0"}
+			}
+		},
+		{
+			"from": [6, 9, 5],
+			"to": [7, 18, 6],
+			"faces": {
+				"north": {"uv": [4.5, 0.5, 5, 5], "texture": "#0"},
+				"east": {"uv": [11, 0.5, 11.5, 5], "texture": "#0"},
+				"south": {"uv": [11, 0.5, 11.5, 5], "texture": "#0"},
+				"west": {"uv": [4.5, 0.5, 5, 5], "texture": "#0"},
+				"up": {"uv": [4.5, 0.5, 5, 1], "texture": "#0"},
+				"down": {"uv": [4.5, 4.5, 5, 5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 4, 5],
+			"to": [11, 9, 6],
+			"faces": {
+				"north": {"uv": [2.5, 5, 5.5, 7.5], "texture": "#0"},
+				"east": {"uv": [2.5, 5, 3, 7.5], "texture": "#0"},
+				"south": {"uv": [10.5, 5, 13.5, 7.5], "texture": "#0"},
+				"west": {"uv": [5, 5, 5.5, 7.5], "texture": "#0"},
+				"up": {"uv": [2.5, 5, 5.5, 5.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 7, 5.5, 7.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 5, 5],
+			"to": [13, 8, 6],
+			"faces": {
+				"north": {"uv": [1.5, 5.5, 2.5, 7], "texture": "#0"},
+				"east": {"uv": [1.5, 5.5, 2, 7], "texture": "#0"},
+				"south": {"uv": [1.5, 5.5, 2.5, 7], "texture": "#0"},
+				"west": {"uv": [2, 5.5, 2.5, 7], "texture": "#0"},
+				"up": {"uv": [1.5, 5.5, 2.5, 6], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [1.5, 6.5, 2.5, 7], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 5, 5],
+			"to": [5, 8, 6],
+			"faces": {
+				"north": {"uv": [5.5, 5.5, 6.5, 7], "texture": "#0"},
+				"east": {"uv": [5.5, 5.5, 6, 7], "texture": "#0"},
+				"south": {"uv": [5.5, 5.5, 6.5, 7], "texture": "#0"},
+				"west": {"uv": [6, 5.5, 6.5, 7], "texture": "#0"},
+				"up": {"uv": [5.5, 5.5, 6.5, 6], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [5.5, 6.5, 6.5, 7], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [9, -5, 5],
+			"to": [10, 4, 6],
+			"faces": {
+				"north": {"uv": [3, 7.5, 3.5, 12], "texture": "#0"},
+				"east": {"uv": [3, 7.5, 3.5, 12], "texture": "#0"},
+				"south": {"uv": [12.5, 7.5, 13, 12], "texture": "#0"},
+				"west": {"uv": [3, 7.5, 3.5, 12], "texture": "#0"},
+				"up": {"uv": [3, 7.5, 3.5, 8], "texture": "#0"},
+				"down": {"uv": [3, 11.5, 3.5, 12], "texture": "#0"}
+			}
+		},
+		{
+			"from": [9, 9, 5],
+			"to": [10, 18, 6],
+			"faces": {
+				"north": {"uv": [3, 0.5, 3.5, 5], "texture": "#0"},
+				"east": {"uv": [3, 0.5, 3.5, 5], "texture": "#0"},
+				"south": {"uv": [12.5, 0.5, 13, 5], "texture": "#0"},
+				"west": {"uv": [12.5, 0.5, 13, 5], "texture": "#0"},
+				"up": {"uv": [3, 0.5, 3.5, 1], "texture": "#0"},
+				"down": {"uv": [3, 4.5, 3.5, 5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [10, -3, 6],
+			"to": [11, 16, 7],
+			"faces": {
+				"north": {"uv": [2.5, 1.5, 3, 11], "texture": "#0"},
+				"east": {"uv": [2.5, 1.5, 3, 11], "texture": "#0"},
+				"south": {"uv": [13, 1.5, 13.5, 11], "texture": "#0"},
+				"west": {"uv": [13, 1.5, 13.5, 11], "texture": "#0"},
+				"up": {"uv": [2.5, 1.5, 3, 2], "texture": "#0"},
+				"down": {"uv": [2.5, 10.5, 3, 11], "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, -3, 6],
+			"to": [6, 16, 7],
+			"faces": {
+				"north": {"uv": [5, 1.5, 5.5, 11], "texture": "#0"},
+				"east": {"uv": [10.5, 1.5, 11, 11], "texture": "#0"},
+				"south": {"uv": [10.5, 1.5, 11, 11], "texture": "#0"},
+				"west": {"uv": [5, 1.5, 5.5, 11], "texture": "#0"},
+				"up": {"uv": [5, 1.5, 5.5, 2], "texture": "#0"},
+				"down": {"uv": [5, 10.5, 5.5, 11], "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, -1, 6],
+			"to": [12, 14, 7],
+			"faces": {
+				"north": {"uv": [2, 2.5, 2.5, 10], "texture": "#0"},
+				"east": {"uv": [2, 2.5, 2.5, 10], "texture": "#0"},
+				"south": {"uv": [13.5, 2.5, 14, 10], "texture": "#0"},
+				"west": {"uv": [13.5, 2.5, 14, 10], "texture": "#0"},
+				"up": {"uv": [2, 2.5, 2.5, 3], "texture": "#0"},
+				"down": {"uv": [2, 9.5, 2.5, 10], "texture": "#0"}
+			}
+		},
+		{
+			"from": [4, -1, 6],
+			"to": [5, 14, 7],
+			"faces": {
+				"north": {"uv": [5.5, 2.5, 6, 10], "texture": "#0"},
+				"east": {"uv": [5.5, 2.5, 6, 10], "texture": "#0"},
+				"south": {"uv": [10, 2.5, 10.5, 10], "texture": "#0"},
+				"west": {"uv": [5.5, 2.5, 6, 10], "texture": "#0"},
+				"up": {"uv": [5.5, 2.5, 6, 3], "texture": "#0"},
+				"down": {"uv": [5.5, 9.5, 6, 10], "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 3, 7],
+			"to": [14, 10, 8],
+			"faces": {
+				"north": {"uv": [1, 4.5, 1.5, 8], "texture": "#0"},
+				"east": {"uv": [1, 4.5, 1.5, 8], "texture": "#0"},
+				"south": {"uv": [14.5, 4.5, 15, 8], "texture": "#0"},
+				"west": {"uv": [14.5, 4.5, 15, 8], "texture": "#0"},
+				"up": {"uv": [1, 4.5, 1.5, 5], "texture": "#0"},
+				"down": {"uv": [1, 7.5, 1.5, 8], "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 3, 7],
+			"to": [3, 10, 8],
+			"faces": {
+				"north": {"uv": [6.5, 4.5, 7, 8], "texture": "#0"},
+				"east": {"uv": [9, 4.5, 9.5, 8], "texture": "#0"},
+				"south": {"uv": [9, 4.5, 9.5, 8], "texture": "#0"},
+				"west": {"uv": [6.5, 4.5, 7, 8], "texture": "#0"},
+				"up": {"uv": [6.5, 4.5, 7, 5], "texture": "#0"},
+				"down": {"uv": [6.5, 7.5, 7, 8], "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 5, 6],
+			"to": [14, 8, 7],
+			"faces": {
+				"north": {"uv": [1, 5.5, 1.5, 7], "texture": "#0"},
+				"east": {"uv": [1, 5.5, 1.5, 7], "texture": "#0"},
+				"south": {"uv": [1, 5.5, 1.5, 7], "texture": "#0"},
+				"west": {"uv": [1, 5.5, 1.5, 7], "texture": "#0"},
+				"up": {"uv": [1, 5.5, 1.5, 7], "texture": "#0"},
+				"down": {"uv": [1, 5.5, 1.5, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 5, 6],
+			"to": [3, 8, 7],
+			"faces": {
+				"north": {"uv": [6.5, 5.5, 7, 7], "texture": "#0"},
+				"east": {"uv": [6.5, 5.5, 7, 7], "texture": "#0"},
+				"south": {"uv": [6.5, 5.5, 7, 7], "texture": "#0"},
+				"west": {"uv": [6.5, 5.5, 7, 7], "texture": "#0"},
+				"up": {"uv": [6.5, 5.5, 7, 6], "texture": "#0"},
+				"down": {"uv": [6.5, 6.5, 7, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [14, 5, 7],
+			"to": [15, 8, 8],
+			"faces": {
+				"north": {"uv": [0.5, 5.5, 1, 7], "texture": "#0"},
+				"east": {"uv": [0.5, 5.5, 1, 7], "texture": "#0"},
+				"south": {"uv": [15, 5.5, 15.5, 7], "texture": "#0"},
+				"west": {"uv": [15, 5.5, 15.5, 7], "texture": "#0"},
+				"up": {"uv": [0.5, 5.5, 1, 6], "texture": "#0"},
+				"down": {"uv": [0.5, 6.5, 1, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [1, 5, 7],
+			"to": [2, 8, 8],
+			"faces": {
+				"north": {"uv": [7, 5.5, 7.5, 7], "texture": "#0"},
+				"east": {"uv": [7, 5.5, 7.5, 7], "texture": "#0"},
+				"south": {"uv": [8.5, 5.5, 9, 7], "texture": "#0"},
+				"west": {"uv": [7, 5.5, 7.5, 7], "texture": "#0"},
+				"up": {"uv": [7, 5.5, 7.5, 6], "texture": "#0"},
+				"down": {"uv": [7, 6.5, 7.5, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [12, 1, 6],
+			"to": [13, 12, 7],
+			"faces": {
+				"north": {"uv": [1.5, 3.5, 2, 9], "texture": "#0"},
+				"east": {"uv": [1.5, 3.5, 2, 9], "texture": "#0"},
+				"south": {"uv": [14, 3.5, 14.5, 9], "texture": "#0"},
+				"west": {"uv": [14, 3.5, 14.5, 9], "texture": "#0"},
+				"up": {"uv": [1.5, 3.5, 2, 4], "texture": "#0"},
+				"down": {"uv": [1.5, 8.5, 2, 9], "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 1, 6],
+			"to": [4, 12, 7],
+			"faces": {
+				"north": {"uv": [6, 3.5, 6.5, 9], "texture": "#0"},
+				"east": {"uv": [9.5, 3.5, 10, 9], "texture": "#0"},
+				"south": {"uv": [9.5, 3.5, 10, 9], "texture": "#0"},
+				"west": {"uv": [6, 3.5, 6.5, 9], "texture": "#0"},
+				"up": {"uv": [6, 3.5, 6.5, 4], "texture": "#0"},
+				"down": {"uv": [6, 8.5, 6.5, 9], "texture": "#0"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"ground": {
+			"translation": [0, 3, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.5, 1.25, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"head": {
+			"translation": [0, 1.25, -6.56],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 1.2, 0],
+			"scale": [0.66, 0.66, 0.66]
+		}
+	},
+	"overrides": [{
+		"predicate": { "blocking": 1 },
+		"model": "tfc:item/metal/shield/blue_steel_blocking"
+		}
+	],
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6, 7]
+		}, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/blue_steel_blocking.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/blue_steel_blocking.json
@@ -1,0 +1,49 @@
+{
+	"credit": "Made with Blockbench",
+	"parent":"tfc:item/metal/shield/blue_steel",
+	"textures": {
+		"0": "tfc:item/metal/shield/blue_steel",
+		"particle": "tfc:item/metal/shield/blue_steel"
+	},
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"firstperson_lefthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"ground": {
+			"translation": [0, 1, 0],
+			"scale": [0.3, 0.3, 0.3]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.5, 1.25, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"head": {
+			"translation": [0, 1.25, -6.56],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 4.25, 0.12],
+			"scale": [2.02, 2.02, 2.02]
+		}
+	},
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6, 7]
+		}, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/bronze.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/bronze.json
@@ -1,0 +1,408 @@
+{
+	"credit": "Made with Blockbench",
+	"textures": {
+		"0": "tfc:item/metal/shield/bronze",
+		"particle": "tfc:item/metal/shield/bronze"
+	},
+	"elements": [
+		{
+			"name": "board",
+			"from": [2, 6, 7],
+			"to": [14, 10, 8],
+			"faces": {
+				"north": {"uv": [0.5, 14, 6.5, 16], "rotation": 180, "texture": "#0"},
+				"east": {"uv": [6, 14, 6.5, 16], "texture": "#0"},
+				"south": {"uv": [0.5, 14, 6.5, 16], "texture": "#0"},
+				"west": {"uv": [0.5, 14, 1, 16], "texture": "#0"},
+				"up": {"uv": [0.5, 14, 6.5, 14.5], "texture": "#0"},
+				"down": {"uv": [0.5, 15.5, 6.5, 16], "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 6, 12],
+			"to": [10, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 6, 12],
+			"to": [6, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 5, 7],
+			"to": [10, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 5, 7],
+			"to": [6, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 10, 7],
+			"to": [10, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 10, 7],
+			"to": [6, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 5, 5],
+			"to": [11, 11, 6],
+			"faces": {
+				"north": {"uv": [2.5, 2.5, 5.5, 5.5], "texture": "#0"},
+				"east": {"uv": [2.5, 2.5, 3, 5.5], "texture": "#0"},
+				"south": {"uv": [10.5, 2.5, 13.5, 5.5], "texture": "#0"},
+				"west": {"uv": [5, 2.5, 5.5, 5.5], "texture": "#0"},
+				"up": {"uv": [2.5, 2.5, 5.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 5, 5.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 3, 6],
+			"to": [13, 13, 7],
+			"faces": {
+				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#0"},
+				"east": {"uv": [1.5, 1.5, 2, 6.5], "texture": "#0"},
+				"south": {"uv": [9.5, 1.5, 14.5, 6.5], "texture": "#0"},
+				"west": {"uv": [6, 1.5, 6.5, 6.5], "texture": "#0"},
+				"up": {"uv": [1.5, 1.5, 6.5, 2], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [1.5, 6, 6.5, 6.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 13, 6],
+			"to": [11, 14, 7],
+			"faces": {
+				"north": {"uv": [2.5, 1, 5.5, 1.5], "texture": "#0"},
+				"east": {"uv": [2.5, 1, 3, 1.5], "texture": "#0"},
+				"south": {"uv": [10.5, 1, 13.5, 1.5], "texture": "#0"},
+				"west": {"uv": [5, 1, 5.5, 1.5], "texture": "#0"},
+				"up": {"uv": [2.5, 1, 5.5, 1.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 1, 5.5, 1.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 14, 7],
+			"to": [11, 15, 8],
+			"faces": {
+				"north": {"uv": [2.5, 0.5, 5.5, 1], "texture": "#0"},
+				"east": {"uv": [2.5, 0.5, 3, 1], "texture": "#0"},
+				"south": {"uv": [10.5, 0.5, 13.5, 1], "texture": "#0"},
+				"west": {"uv": [5, 0.5, 5.5, 1], "texture": "#0"},
+				"up": {"uv": [2.5, 0.5, 5.5, 1], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [10.5, 0.5, 13.5, 1], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 1, 7],
+			"to": [11, 2, 8],
+			"faces": {
+				"north": {"uv": [2.5, 7, 5.5, 7.5], "texture": "#0"},
+				"east": {"uv": [2.5, 7, 3, 7.5], "texture": "#0"},
+				"south": {"uv": [10.5, 7, 13.5, 7.5], "texture": "#0"},
+				"west": {"uv": [5, 7, 5.5, 7.5], "texture": "#0"},
+				"up": {"uv": [10.5, 7, 13.5, 7.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 7, 5.5, 7.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 2, 6],
+			"to": [11, 3, 7],
+			"faces": {
+				"north": {"uv": [2.5, 6.5, 5.5, 7], "texture": "#0"},
+				"east": {"uv": [2.5, 6.5, 3, 7], "texture": "#0"},
+				"south": {"uv": [10.5, 6.5, 13.5, 7], "texture": "#0"},
+				"west": {"uv": [5, 6.5, 5.5, 7], "texture": "#0"},
+				"up": {"uv": [2.5, 6.5, 5.5, 7], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 6.5, 5.5, 7], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 5, 6],
+			"to": [14, 11, 7],
+			"faces": {
+				"north": {"uv": [1, 2.5, 1.5, 5.5], "texture": "#0"},
+				"east": {"uv": [1, 2.5, 1.5, 5.5], "texture": "#0"},
+				"south": {"uv": [14.5, 2.5, 15, 5.5], "texture": "#0"},
+				"west": {"uv": [1, 2.5, 1.5, 5.5], "texture": "#0"},
+				"up": {"uv": [1, 2.5, 1.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [1, 5, 1.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [14, 5, 7],
+			"to": [15, 11, 8],
+			"faces": {
+				"north": {"uv": [0.5, 2.5, 1, 5.5], "texture": "#0"},
+				"east": {"uv": [0.5, 2.5, 1, 5.5], "texture": "#0"},
+				"south": {"uv": [15, 2.5, 15.5, 5.5], "texture": "#0"},
+				"west": {"uv": [15, 2.5, 15.5, 5.5], "texture": "#0"},
+				"up": {"uv": [0.5, 2.5, 1, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [0.5, 5, 1, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 11, 7],
+			"to": [14, 13, 8],
+			"faces": {
+				"north": {"uv": [1, 1.5, 1.5, 2.5], "texture": "#0"},
+				"east": {"uv": [1, 1.5, 1.5, 2.5], "texture": "#0"},
+				"south": {"uv": [14.5, 1.5, 15, 2.5], "texture": "#0"},
+				"west": {"uv": [14.5, 1.5, 15, 2.5], "texture": "#0"},
+				"up": {"uv": [1, 1.5, 1.5, 2], "texture": "#0"},
+				"down": {"uv": [14.5, 2, 15, 2.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 13, 7],
+			"to": [13, 14, 8],
+			"faces": {
+				"north": {"uv": [1.5, 1, 2.5, 1.5], "texture": "#0"},
+				"east": {"uv": [1.5, 1, 2, 1.5], "texture": "#0"},
+				"south": {"uv": [13.5, 1, 14.5, 1.5], "texture": "#0"},
+				"west": {"uv": [13.5, 1, 14, 1.5], "texture": "#0"},
+				"up": {"uv": [1.5, 1, 2.5, 1.5], "texture": "#0"},
+				"down": {"uv": [13.5, 1, 14.5, 1.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 2, 7],
+			"to": [13, 3, 8],
+			"faces": {
+				"north": {"uv": [1.5, 6.5, 2.5, 7], "texture": "#0"},
+				"east": {"uv": [1.5, 6.5, 2, 7], "texture": "#0"},
+				"south": {"uv": [13.5, 6.5, 14.5, 7], "texture": "#0"},
+				"west": {"uv": [13.5, 6.5, 14, 7], "texture": "#0"},
+				"up": {"uv": [13.5, 6.5, 14.5, 7], "texture": "#0"},
+				"down": {"uv": [1.5, 6.5, 2.5, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 13, 7],
+			"to": [5, 14, 8],
+			"faces": {
+				"north": {"uv": [5.5, 1, 6.5, 1.5], "texture": "#0"},
+				"east": {"uv": [10, 1, 10.5, 1.5], "texture": "#0"},
+				"south": {"uv": [9.5, 1, 10.5, 1.5], "texture": "#0"},
+				"west": {"uv": [6, 1, 6.5, 1.5], "texture": "#0"},
+				"up": {"uv": [5.5, 1, 6.5, 1.5], "texture": "#0"},
+				"down": {"uv": [9.5, 1, 10.5, 1.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 2, 7],
+			"to": [5, 3, 8],
+			"faces": {
+				"north": {"uv": [5.5, 6.5, 6.5, 7], "texture": "#0"},
+				"east": {"uv": [10, 6.5, 10.5, 7], "texture": "#0"},
+				"south": {"uv": [9.5, 6.5, 10.5, 7], "texture": "#0"},
+				"west": {"uv": [6, 6.5, 6.5, 7], "texture": "#0"},
+				"up": {"uv": [9.5, 6.5, 10.5, 7], "texture": "#0"},
+				"down": {"uv": [5.5, 6.5, 6.5, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 3, 7],
+			"to": [14, 5, 8],
+			"faces": {
+				"north": {"uv": [1, 5.5, 1.5, 6.5], "texture": "#0"},
+				"east": {"uv": [1, 5.5, 1.5, 6.5], "texture": "#0"},
+				"south": {"uv": [14.5, 5.5, 15, 6.5], "texture": "#0"},
+				"west": {"uv": [14.5, 5.5, 15, 6.5], "texture": "#0"},
+				"up": {"uv": [1, 5.5, 1.5, 6], "texture": "#0"},
+				"down": {"uv": [14.5, 6, 15, 6.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 11, 7],
+			"to": [3, 13, 8],
+			"faces": {
+				"north": {"uv": [6.5, 1.5, 7, 2.5], "texture": "#0"},
+				"east": {"uv": [9, 1.5, 9.5, 2.5], "texture": "#0"},
+				"south": {"uv": [9, 1.5, 9.5, 2.5], "texture": "#0"},
+				"west": {"uv": [6.5, 1.5, 7, 2.5], "texture": "#0"},
+				"up": {"uv": [6.5, 1.5, 7, 2], "texture": "#0"},
+				"down": {"uv": [9, 2, 9.5, 2.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 3, 7],
+			"to": [3, 5, 8],
+			"faces": {
+				"north": {"uv": [6.5, 5.5, 7, 6.5], "texture": "#0"},
+				"east": {"uv": [9, 5.5, 9.5, 6.5], "texture": "#0"},
+				"south": {"uv": [9, 5.5, 9.5, 6.5], "texture": "#0"},
+				"west": {"uv": [6.5, 5.5, 7, 6.5], "texture": "#0"},
+				"up": {"uv": [9, 5.5, 9.5, 6], "texture": "#0"},
+				"down": {"uv": [6.5, 6, 7, 6.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [1, 5, 7],
+			"to": [2, 11, 8],
+			"faces": {
+				"north": {"uv": [7, 2.5, 7.5, 5.5], "texture": "#0"},
+				"east": {"uv": [8.5, 2.5, 9, 5.5], "texture": "#0"},
+				"south": {"uv": [8.5, 2.5, 9, 5.5], "texture": "#0"},
+				"west": {"uv": [7, 2.5, 7.5, 5.5], "texture": "#0"},
+				"up": {"uv": [7, 2.5, 7.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [7, 5, 7.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 5, 6],
+			"to": [3, 11, 7],
+			"faces": {
+				"north": {"uv": [6.5, 2.5, 7, 5.5], "texture": "#0"},
+				"east": {"uv": [6.5, 2.5, 7, 5.5], "texture": "#0"},
+				"south": {"uv": [9, 2.5, 9.5, 5.5], "texture": "#0"},
+				"west": {"uv": [6.5, 2.5, 7, 5.5], "texture": "#0"},
+				"up": {"uv": [6.5, 2.5, 7, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [6.5, 5, 7, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 5, 5],
+			"to": [12, 11, 6],
+			"faces": {
+				"north": {"uv": [2, 2.5, 2.5, 5.5], "texture": "#0"},
+				"east": {"uv": [2, 2.5, 2.5, 5.5], "texture": "#0"},
+				"south": {"uv": [13.5, 2.5, 14, 5.5], "texture": "#0"},
+				"west": {"uv": [2, 2.5, 2.5, 5.5], "texture": "#0"},
+				"up": {"uv": [2, 2.5, 2.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2, 5, 2.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [4, 5, 5],
+			"to": [5, 11, 6],
+			"faces": {
+				"north": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"east": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"south": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"west": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"up": {"uv": [5.5, 2.5, 6, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [5.5, 5, 6, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 11, 5],
+			"to": [11, 12, 6],
+			"faces": {
+				"north": {"uv": [2.5, 2, 5.5, 2.5], "texture": "#0"},
+				"east": {"uv": [2.5, 2, 3, 2.5], "texture": "#0"},
+				"south": {"uv": [10.5, 2, 13.5, 2.5], "texture": "#0"},
+				"west": {"uv": [5, 2, 5.5, 2.5], "texture": "#0"},
+				"up": {"uv": [2.5, 2, 5.5, 2.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 2, 5.5, 2.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 4, 5],
+			"to": [11, 5, 6],
+			"faces": {
+				"north": {"uv": [2.5, 5.5, 5.5, 6], "texture": "#0"},
+				"east": {"uv": [2.5, 5.5, 3, 6], "texture": "#0"},
+				"south": {"uv": [2.5, 5.5, 5.5, 6], "texture": "#0"},
+				"west": {"uv": [5, 5.5, 5.5, 6], "texture": "#0"},
+				"up": {"uv": [2.5, 5.5, 5.5, 6], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 5.5, 5.5, 6], "rotation": 180, "texture": "#0"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"ground": {
+			"translation": [0, 3, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.25, 0.25, 0],
+			"scale": [0.65, 0.65, 0.65]
+		},
+		"head": {
+			"rotation": [90, 0, 0],
+			"translation": [0, 5.5, -0.5],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 0, 0],
+			"scale": [0.75, 0.75, 0.75]
+		}
+	},
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6]
+		}, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28
+	],
+	"overrides": [{
+		"predicate": { "blocking": 1 },
+		"model": "tfc:item/metal/shield/bronze_blocking"
+		}
+	]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/bronze_blocking.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/bronze_blocking.json
@@ -1,0 +1,51 @@
+{
+	"credit": "Made with Blockbench",
+	"parent":"tfc:item/metal/shield/bronze",
+	"textures": {
+		"0": "tfc:item/metal/shield/bronze",
+		"particle": "tfc:item/metal/shield/bronze"
+	},
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"firstperson_lefthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"ground": {
+			"translation": [0, 2, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.25, 0.25, 0],
+			"scale": [0.65, 0.65, 0.65]
+		},
+		"head": {
+			"rotation": [90, 0, 0],
+			"translation": [0, 5.5, -0.5],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 0, -2.13],
+			"scale": [2.02, 2.02, 2.02]
+		}
+	},
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6]
+		}, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28
+	]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/copper.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/copper.json
@@ -1,0 +1,408 @@
+{
+	"credit": "Made with Blockbench",
+	"textures": {
+		"0": "tfc:item/metal/shield/copper",
+		"particle": "tfc:item/metal/shield/copper"
+	},
+	"elements": [
+		{
+			"name": "board",
+			"from": [2, 6, 7],
+			"to": [14, 10, 8],
+			"faces": {
+				"north": {"uv": [0.5, 14, 6.5, 16], "rotation": 180, "texture": "#0"},
+				"east": {"uv": [6, 14, 6.5, 16], "texture": "#0"},
+				"south": {"uv": [0.5, 14, 6.5, 16], "texture": "#0"},
+				"west": {"uv": [0.5, 14, 1, 16], "texture": "#0"},
+				"up": {"uv": [0.5, 14, 6.5, 14.5], "texture": "#0"},
+				"down": {"uv": [0.5, 15.5, 6.5, 16], "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 6, 12],
+			"to": [10, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 6, 12],
+			"to": [6, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 5, 7],
+			"to": [10, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 5, 7],
+			"to": [6, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 10, 7],
+			"to": [10, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 10, 7],
+			"to": [6, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 5, 5],
+			"to": [11, 11, 6],
+			"faces": {
+				"north": {"uv": [2.5, 2.5, 5.5, 5.5], "texture": "#0"},
+				"east": {"uv": [2.5, 2.5, 3, 5.5], "texture": "#0"},
+				"south": {"uv": [10.5, 2.5, 13.5, 5.5], "texture": "#0"},
+				"west": {"uv": [5, 2.5, 5.5, 5.5], "texture": "#0"},
+				"up": {"uv": [2.5, 2.5, 5.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 5, 5.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 3, 6],
+			"to": [13, 13, 7],
+			"faces": {
+				"north": {"uv": [1.5, 1.5, 6.5, 6.5], "texture": "#0"},
+				"east": {"uv": [1.5, 1.5, 2, 6.5], "texture": "#0"},
+				"south": {"uv": [9.5, 1.5, 14.5, 6.5], "texture": "#0"},
+				"west": {"uv": [6, 1.5, 6.5, 6.5], "texture": "#0"},
+				"up": {"uv": [1.5, 1.5, 6.5, 2], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [1.5, 6, 6.5, 6.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 13, 6],
+			"to": [11, 14, 7],
+			"faces": {
+				"north": {"uv": [2.5, 1, 5.5, 1.5], "texture": "#0"},
+				"east": {"uv": [2.5, 1, 3, 1.5], "texture": "#0"},
+				"south": {"uv": [10.5, 1, 13.5, 1.5], "texture": "#0"},
+				"west": {"uv": [5, 1, 5.5, 1.5], "texture": "#0"},
+				"up": {"uv": [2.5, 1, 5.5, 1.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 1, 5.5, 1.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 14, 7],
+			"to": [11, 15, 8],
+			"faces": {
+				"north": {"uv": [2.5, 0.5, 5.5, 1], "texture": "#0"},
+				"east": {"uv": [2.5, 0.5, 3, 1], "texture": "#0"},
+				"south": {"uv": [10.5, 0.5, 13.5, 1], "texture": "#0"},
+				"west": {"uv": [5, 0.5, 5.5, 1], "texture": "#0"},
+				"up": {"uv": [2.5, 0.5, 5.5, 1], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [10.5, 0.5, 13.5, 1], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 1, 7],
+			"to": [11, 2, 8],
+			"faces": {
+				"north": {"uv": [2.5, 7, 5.5, 7.5], "texture": "#0"},
+				"east": {"uv": [2.5, 7, 3, 7.5], "texture": "#0"},
+				"south": {"uv": [10.5, 7, 13.5, 7.5], "texture": "#0"},
+				"west": {"uv": [5, 7, 5.5, 7.5], "texture": "#0"},
+				"up": {"uv": [10.5, 7, 13.5, 7.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 7, 5.5, 7.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 2, 6],
+			"to": [11, 3, 7],
+			"faces": {
+				"north": {"uv": [2.5, 6.5, 5.5, 7], "texture": "#0"},
+				"east": {"uv": [2.5, 6.5, 3, 7], "texture": "#0"},
+				"south": {"uv": [10.5, 6.5, 13.5, 7], "texture": "#0"},
+				"west": {"uv": [5, 6.5, 5.5, 7], "texture": "#0"},
+				"up": {"uv": [2.5, 6.5, 5.5, 7], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 6.5, 5.5, 7], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 5, 6],
+			"to": [14, 11, 7],
+			"faces": {
+				"north": {"uv": [1, 2.5, 1.5, 5.5], "texture": "#0"},
+				"east": {"uv": [1, 2.5, 1.5, 5.5], "texture": "#0"},
+				"south": {"uv": [14.5, 2.5, 15, 5.5], "texture": "#0"},
+				"west": {"uv": [1, 2.5, 1.5, 5.5], "texture": "#0"},
+				"up": {"uv": [1, 2.5, 1.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [1, 5, 1.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [14, 5, 7],
+			"to": [15, 11, 8],
+			"faces": {
+				"north": {"uv": [0.5, 2.5, 1, 5.5], "texture": "#0"},
+				"east": {"uv": [0.5, 2.5, 1, 5.5], "texture": "#0"},
+				"south": {"uv": [15, 2.5, 15.5, 5.5], "texture": "#0"},
+				"west": {"uv": [15, 2.5, 15.5, 5.5], "texture": "#0"},
+				"up": {"uv": [0.5, 2.5, 1, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [0.5, 5, 1, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 11, 7],
+			"to": [14, 13, 8],
+			"faces": {
+				"north": {"uv": [1, 1.5, 1.5, 2.5], "texture": "#0"},
+				"east": {"uv": [1, 1.5, 1.5, 2.5], "texture": "#0"},
+				"south": {"uv": [14.5, 1.5, 15, 2.5], "texture": "#0"},
+				"west": {"uv": [14.5, 1.5, 15, 2.5], "texture": "#0"},
+				"up": {"uv": [1, 1.5, 1.5, 2], "texture": "#0"},
+				"down": {"uv": [14.5, 2, 15, 2.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 13, 7],
+			"to": [13, 14, 8],
+			"faces": {
+				"north": {"uv": [1.5, 1, 2.5, 1.5], "texture": "#0"},
+				"east": {"uv": [1.5, 1, 2, 1.5], "texture": "#0"},
+				"south": {"uv": [13.5, 1, 14.5, 1.5], "texture": "#0"},
+				"west": {"uv": [13.5, 1, 14, 1.5], "texture": "#0"},
+				"up": {"uv": [1.5, 1, 2.5, 1.5], "texture": "#0"},
+				"down": {"uv": [13.5, 1, 14.5, 1.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 2, 7],
+			"to": [13, 3, 8],
+			"faces": {
+				"north": {"uv": [1.5, 6.5, 2.5, 7], "texture": "#0"},
+				"east": {"uv": [1.5, 6.5, 2, 7], "texture": "#0"},
+				"south": {"uv": [13.5, 6.5, 14.5, 7], "texture": "#0"},
+				"west": {"uv": [13.5, 6.5, 14, 7], "texture": "#0"},
+				"up": {"uv": [13.5, 6.5, 14.5, 7], "texture": "#0"},
+				"down": {"uv": [1.5, 6.5, 2.5, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 13, 7],
+			"to": [5, 14, 8],
+			"faces": {
+				"north": {"uv": [5.5, 1, 6.5, 1.5], "texture": "#0"},
+				"east": {"uv": [10, 1, 10.5, 1.5], "texture": "#0"},
+				"south": {"uv": [9.5, 1, 10.5, 1.5], "texture": "#0"},
+				"west": {"uv": [6, 1, 6.5, 1.5], "texture": "#0"},
+				"up": {"uv": [5.5, 1, 6.5, 1.5], "texture": "#0"},
+				"down": {"uv": [9.5, 1, 10.5, 1.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 2, 7],
+			"to": [5, 3, 8],
+			"faces": {
+				"north": {"uv": [5.5, 6.5, 6.5, 7], "texture": "#0"},
+				"east": {"uv": [10, 6.5, 10.5, 7], "texture": "#0"},
+				"south": {"uv": [9.5, 6.5, 10.5, 7], "texture": "#0"},
+				"west": {"uv": [6, 6.5, 6.5, 7], "texture": "#0"},
+				"up": {"uv": [9.5, 6.5, 10.5, 7], "texture": "#0"},
+				"down": {"uv": [5.5, 6.5, 6.5, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 3, 7],
+			"to": [14, 5, 8],
+			"faces": {
+				"north": {"uv": [1, 5.5, 1.5, 6.5], "texture": "#0"},
+				"east": {"uv": [1, 5.5, 1.5, 6.5], "texture": "#0"},
+				"south": {"uv": [14.5, 5.5, 15, 6.5], "texture": "#0"},
+				"west": {"uv": [14.5, 5.5, 15, 6.5], "texture": "#0"},
+				"up": {"uv": [1, 5.5, 1.5, 6], "texture": "#0"},
+				"down": {"uv": [14.5, 6, 15, 6.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 11, 7],
+			"to": [3, 13, 8],
+			"faces": {
+				"north": {"uv": [6.5, 1.5, 7, 2.5], "texture": "#0"},
+				"east": {"uv": [9, 1.5, 9.5, 2.5], "texture": "#0"},
+				"south": {"uv": [9, 1.5, 9.5, 2.5], "texture": "#0"},
+				"west": {"uv": [6.5, 1.5, 7, 2.5], "texture": "#0"},
+				"up": {"uv": [6.5, 1.5, 7, 2], "texture": "#0"},
+				"down": {"uv": [9, 2, 9.5, 2.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 3, 7],
+			"to": [3, 5, 8],
+			"faces": {
+				"north": {"uv": [6.5, 5.5, 7, 6.5], "texture": "#0"},
+				"east": {"uv": [9, 5.5, 9.5, 6.5], "texture": "#0"},
+				"south": {"uv": [9, 5.5, 9.5, 6.5], "texture": "#0"},
+				"west": {"uv": [6.5, 5.5, 7, 6.5], "texture": "#0"},
+				"up": {"uv": [9, 5.5, 9.5, 6], "texture": "#0"},
+				"down": {"uv": [6.5, 6, 7, 6.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [1, 5, 7],
+			"to": [2, 11, 8],
+			"faces": {
+				"north": {"uv": [7, 2.5, 7.5, 5.5], "texture": "#0"},
+				"east": {"uv": [8.5, 2.5, 9, 5.5], "texture": "#0"},
+				"south": {"uv": [8.5, 2.5, 9, 5.5], "texture": "#0"},
+				"west": {"uv": [7, 2.5, 7.5, 5.5], "texture": "#0"},
+				"up": {"uv": [7, 2.5, 7.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [7, 5, 7.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 5, 6],
+			"to": [3, 11, 7],
+			"faces": {
+				"north": {"uv": [6.5, 2.5, 7, 5.5], "texture": "#0"},
+				"east": {"uv": [6.5, 2.5, 7, 5.5], "texture": "#0"},
+				"south": {"uv": [9, 2.5, 9.5, 5.5], "texture": "#0"},
+				"west": {"uv": [6.5, 2.5, 7, 5.5], "texture": "#0"},
+				"up": {"uv": [6.5, 2.5, 7, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [6.5, 5, 7, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 5, 5],
+			"to": [12, 11, 6],
+			"faces": {
+				"north": {"uv": [2, 2.5, 2.5, 5.5], "texture": "#0"},
+				"east": {"uv": [2, 2.5, 2.5, 5.5], "texture": "#0"},
+				"south": {"uv": [13.5, 2.5, 14, 5.5], "texture": "#0"},
+				"west": {"uv": [2, 2.5, 2.5, 5.5], "texture": "#0"},
+				"up": {"uv": [2, 2.5, 2.5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2, 5, 2.5, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [4, 5, 5],
+			"to": [5, 11, 6],
+			"faces": {
+				"north": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"east": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"south": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"west": {"uv": [5.5, 2.5, 6, 5.5], "texture": "#0"},
+				"up": {"uv": [5.5, 2.5, 6, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [5.5, 5, 6, 5.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 11, 5],
+			"to": [11, 12, 6],
+			"faces": {
+				"north": {"uv": [2.5, 2, 5.5, 2.5], "texture": "#0"},
+				"east": {"uv": [2.5, 2, 3, 2.5], "texture": "#0"},
+				"south": {"uv": [10.5, 2, 13.5, 2.5], "texture": "#0"},
+				"west": {"uv": [5, 2, 5.5, 2.5], "texture": "#0"},
+				"up": {"uv": [2.5, 2, 5.5, 2.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 2, 5.5, 2.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 4, 5],
+			"to": [11, 5, 6],
+			"faces": {
+				"north": {"uv": [2.5, 5.5, 5.5, 6], "texture": "#0"},
+				"east": {"uv": [2.5, 5.5, 3, 6], "texture": "#0"},
+				"south": {"uv": [2.5, 5.5, 5.5, 6], "texture": "#0"},
+				"west": {"uv": [5, 5.5, 5.5, 6], "texture": "#0"},
+				"up": {"uv": [2.5, 5.5, 5.5, 6], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 5.5, 5.5, 6], "rotation": 180, "texture": "#0"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"ground": {
+			"translation": [0, 3, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.25, 0.25, 0],
+			"scale": [0.65, 0.65, 0.65]
+		},
+		"head": {
+			"rotation": [90, 0, 0],
+			"translation": [0, 5.5, -0.5],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 0, 0],
+			"scale": [0.75, 0.75, 0.75]
+		}
+	},
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6]
+		}, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28
+	],
+	"overrides": [{
+		"predicate": { "blocking": 1 },
+		"model": "tfc:item/metal/shield/copper_blocking"
+		}
+	]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/copper_blocking.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/copper_blocking.json
@@ -1,0 +1,51 @@
+{
+	"credit": "Made with Blockbench",
+	"parent":"tfc:item/metal/shield/copper",
+	"textures": {
+		"0": "tfc:item/metal/shield/copper",
+		"particle": "tfc:item/metal/shield/copper"
+	},
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"firstperson_lefthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"ground": {
+			"translation": [0, 2, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.25, 0.25, 0],
+			"scale": [0.65, 0.65, 0.65]
+		},
+		"head": {
+			"rotation": [90, 0, 0],
+			"translation": [0, 5.5, -0.5],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 0, -2.13],
+			"scale": [2.02, 2.02, 2.02]
+		}
+	},
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6]
+		}, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28
+	]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/red_steel.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/red_steel.json
@@ -1,0 +1,417 @@
+{
+	"credit": "Made with Blockbench",
+	"textures": {
+		"0": "tfc:item/metal/shield/red_steel",
+		"particle": "tfc:item/metal/shield/red_steel"
+	},
+	"elements": [
+		{
+			"name": "handle",
+			"from": [9, 6, 12],
+			"to": [10, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 6, 12],
+			"to": [6, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 5, 7],
+			"to": [10, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 5, 7],
+			"to": [6, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 10, 7],
+			"to": [10, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 10, 7],
+			"to": [6, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 6, 7],
+			"to": [13, 10, 8],
+			"faces": {
+				"north": {"uv": [1, 14, 6, 16], "texture": "#0"},
+				"east": {"uv": [1, 14, 1.5, 16], "texture": "#0"},
+				"south": {"uv": [1, 14, 6, 16], "texture": "#0"},
+				"west": {"uv": [5.5, 14, 6, 16], "texture": "#0"},
+				"up": {"uv": [1, 14, 6, 14.5], "texture": "#0"},
+				"down": {"uv": [1, 15.5, 6, 16], "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 5, 6],
+			"to": [11, 11, 7],
+			"faces": {
+				"north": {"uv": [2, 14, 5, 16], "texture": "#0"},
+				"east": {"uv": [4.5, 14, 5, 16], "texture": "#0"},
+				"south": {"uv": [2, 14, 5, 16], "texture": "#0"},
+				"west": {"uv": [2, 14, 2.5, 16], "texture": "#0"},
+				"up": {"uv": [2, 14, 5, 14.5], "texture": "#0"},
+				"down": {"uv": [2, 15.5, 5, 16], "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, -6, 5],
+			"to": [7, 18, 6],
+			"faces": {
+				"north": {"uv": [4.5, 0.5, 5.5, 12.5], "texture": "#0"},
+				"east": {"uv": [4.5, 0.5, 5, 12.5], "texture": "#0"},
+				"south": {"uv": [10.5, 0.5, 11.5, 12.5], "texture": "#0"},
+				"west": {"uv": [5, 0.5, 5.5, 12.5], "texture": "#0"},
+				"up": {"uv": [4.5, 0.5, 5.5, 1], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [4.5, 12, 5.5, 12.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [9, -6, 5],
+			"to": [11, 18, 6],
+			"faces": {
+				"north": {"uv": [2.5, 0.5, 3.5, 12.5], "texture": "#0"},
+				"east": {"uv": [2.5, 0.5, 3, 12.5], "texture": "#0"},
+				"south": {"uv": [12.5, 0.5, 13.5, 12.5], "texture": "#0"},
+				"west": {"uv": [3, 0.5, 3.5, 12.5], "texture": "#0"},
+				"up": {"uv": [2.5, 0.5, 3.5, 1], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 12, 3.5, 12.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [4, -5, 6],
+			"to": [5, 18, 7],
+			"faces": {
+				"north": {"uv": [5.5, 0.5, 6, 12], "texture": "#0"},
+				"east": {"uv": [10, 0.5, 10.5, 12], "texture": "#0"},
+				"south": {"uv": [10, 0.5, 10.5, 12], "texture": "#0"},
+				"west": {"uv": [5.5, 0.5, 6, 12], "texture": "#0"},
+				"up": {"uv": [5.5, 0.5, 6, 1], "texture": "#0"},
+				"down": {"uv": [5.5, 11.5, 6, 12], "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, -5, 6],
+			"to": [12, 18, 7],
+			"faces": {
+				"north": {"uv": [2, 0.5, 2.5, 12], "texture": "#0"},
+				"east": {"uv": [2, 0.5, 2.5, 12], "texture": "#0"},
+				"south": {"uv": [13.5, 0.5, 14, 12], "texture": "#0"},
+				"west": {"uv": [13.5, 0.5, 14, 12], "texture": "#0"},
+				"up": {"uv": [2, 0.5, 2.5, 1], "texture": "#0"},
+				"down": {"uv": [2, 11.5, 2.5, 12], "texture": "#0"}
+			}
+		},
+		{
+			"from": [12, -4, 6],
+			"to": [13, 17, 7],
+			"faces": {
+				"north": {"uv": [1.5, 1, 2, 11.5], "texture": "#0"},
+				"east": {"uv": [1.5, 1, 2, 11.5], "texture": "#0"},
+				"south": {"uv": [14, 1, 14.5, 11.5], "texture": "#0"},
+				"west": {"uv": [14, 1, 14.5, 11.5], "texture": "#0"},
+				"up": {"uv": [1.5, 1, 2, 1.5], "texture": "#0"},
+				"down": {"uv": [1.5, 11, 2, 11.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, -4, 6],
+			"to": [4, 17, 7],
+			"faces": {
+				"north": {"uv": [6, 1, 6.5, 11.5], "texture": "#0"},
+				"east": {"uv": [9.5, 1, 10, 11.5], "texture": "#0"},
+				"south": {"uv": [9.5, 1, 10, 11.5], "texture": "#0"},
+				"west": {"uv": [6, 1, 6.5, 11.5], "texture": "#0"},
+				"up": {"uv": [6, 1, 6.5, 1.5], "texture": "#0"},
+				"down": {"uv": [6, 11, 6.5, 11.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, -2, 7],
+			"to": [14, 17, 8],
+			"faces": {
+				"north": {"uv": [1, 1, 1.5, 10.5], "texture": "#0"},
+				"east": {"uv": [1, 1, 1.5, 10.5], "texture": "#0"},
+				"south": {"uv": [14.5, 1, 15, 10.5], "texture": "#0"},
+				"west": {"uv": [14.5, 1, 15, 10.5], "texture": "#0"},
+				"up": {"uv": [1, 1, 1.5, 1.5], "texture": "#0"},
+				"down": {"uv": [1, 10, 1.5, 10.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, -2, 7],
+			"to": [3, 17, 8],
+			"faces": {
+				"north": {"uv": [6.5, 1, 7, 10.5], "texture": "#0"},
+				"east": {"uv": [9, 1, 9.5, 10.5], "texture": "#0"},
+				"south": {"uv": [9, 1, 9.5, 10.5], "texture": "#0"},
+				"west": {"uv": [6.5, 1, 7, 10.5], "texture": "#0"},
+				"up": {"uv": [6.5, 1, 7, 1.5], "texture": "#0"},
+				"down": {"uv": [6.5, 10, 7, 10.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [14, 1, 7],
+			"to": [15, 16, 8],
+			"faces": {
+				"north": {"uv": [0.5, 1.5, 1, 9], "texture": "#0"},
+				"east": {"uv": [0.5, 1.5, 1, 9], "texture": "#0"},
+				"south": {"uv": [15, 1.5, 15.5, 9], "texture": "#0"},
+				"west": {"uv": [15, 1.5, 15.5, 9], "texture": "#0"},
+				"up": {"uv": [0.5, 1.5, 1, 2], "texture": "#0"},
+				"down": {"uv": [0.5, 8.5, 1, 9], "texture": "#0"}
+			}
+		},
+		{
+			"from": [1, 1, 7],
+			"to": [2, 16, 8],
+			"faces": {
+				"north": {"uv": [7, 1.5, 7.5, 9], "texture": "#0"},
+				"east": {"uv": [8.5, 1.5, 9, 9], "texture": "#0"},
+				"south": {"uv": [8.5, 1.5, 9, 9], "texture": "#0"},
+				"west": {"uv": [7, 1.5, 7.5, 9], "texture": "#0"},
+				"up": {"uv": [7, 1.5, 7.5, 2], "texture": "#0"},
+				"down": {"uv": [7, 8.5, 7.5, 9], "texture": "#0"}
+			}
+		},
+		{
+			"from": [15, 5, 7],
+			"to": [16, 9, 8],
+			"faces": {
+				"north": {"uv": [0, 5, 0.5, 7], "texture": "#0"},
+				"east": {"uv": [0, 5, 0.5, 7], "texture": "#0"},
+				"south": {"uv": [15.5, 5, 16, 7], "texture": "#0"},
+				"west": {"uv": [0, 5, 0.5, 7], "texture": "#0"},
+				"up": {"uv": [0, 5, 0.5, 5.5], "texture": "#0"},
+				"down": {"uv": [0, 6.5, 0.5, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [0, 5, 7],
+			"to": [1, 9, 8],
+			"faces": {
+				"north": {"uv": [7.5, 5, 8, 7], "texture": "#0"},
+				"east": {"uv": [8, 5, 8.5, 7], "texture": "#0"},
+				"south": {"uv": [8, 5, 8.5, 7], "texture": "#0"},
+				"west": {"uv": [7.5, 5, 8, 7], "texture": "#0"},
+				"up": {"uv": [7.5, 5, 8, 5.5], "texture": "#0"},
+				"down": {"uv": [7.5, 6.5, 8, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [15, 13, 7],
+			"to": [16, 16, 8],
+			"faces": {
+				"north": {"uv": [0, 1.5, 0.5, 3], "texture": "#0"},
+				"east": {"uv": [0, 1.5, 0.5, 3], "texture": "#0"},
+				"south": {"uv": [15.5, 1.5, 16, 3], "texture": "#0"},
+				"west": {"uv": [0, 1.5, 0.5, 3], "texture": "#0"},
+				"up": {"uv": [0, 1.5, 0.5, 2], "texture": "#0"},
+				"down": {"uv": [0, 2.5, 0.5, 3], "texture": "#0"}
+			}
+		},
+		{
+			"from": [0, 13, 7],
+			"to": [1, 16, 8],
+			"faces": {
+				"north": {"uv": [7.5, 1.5, 8, 3], "texture": "#0"},
+				"east": {"uv": [8, 1.5, 8.5, 3], "texture": "#0"},
+				"south": {"uv": [8, 1.5, 8.5, 3], "texture": "#0"},
+				"west": {"uv": [7.5, 1.5, 8, 3], "texture": "#0"},
+				"up": {"uv": [7.5, 1.5, 8, 2], "texture": "#0"},
+				"down": {"uv": [7.5, 2.5, 8, 3], "texture": "#0"}
+			}
+		},
+		{
+			"from": [7, -1, 5],
+			"to": [9, 15, 6],
+			"faces": {
+				"north": {"uv": [3.5, 2, 4.5, 10], "texture": "#0"},
+				"east": {"uv": [3.5, 2, 4, 9.5], "texture": "#0"},
+				"south": {"uv": [11.5, 2, 12.5, 10], "texture": "#0"},
+				"west": {"uv": [4, 2, 4.5, 9.5], "texture": "#0"},
+				"up": {"uv": [3.5, 2, 4.5, 2.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [3.5, 9, 4.5, 9.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [6, 0, 4],
+			"to": [10, 5, 5],
+			"faces": {
+				"north": {"uv": [3, 7, 5, 9.5], "texture": "#0"},
+				"east": {"uv": [3, 7, 3.5, 9.5], "texture": "#0"},
+				"south": {"uv": [11, 7, 13, 9.5], "texture": "#0"},
+				"west": {"uv": [4.5, 7, 5, 9.5], "texture": "#0"},
+				"up": {"uv": [3, 7, 5, 7.5], "texture": "#0"},
+				"down": {"uv": [3, 9, 5, 9.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [6, 9, 4],
+			"to": [10, 14, 5],
+			"faces": {
+				"north": {"uv": [3, 2.5, 5, 5], "texture": "#0"},
+				"east": {"uv": [3, 2.5, 3.5, 5], "texture": "#0"},
+				"south": {"uv": [3, 2.5, 5, 5], "texture": "#0"},
+				"west": {"uv": [4.5, 2.5, 5, 5], "texture": "#0"},
+				"up": {"uv": [3, 2.5, 5, 3], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [3, 4.5, 5, 5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [1, 5, 6],
+			"to": [3, 9, 7],
+			"faces": {
+				"north": {"uv": [6.5, 5, 7.5, 7], "texture": "#0"},
+				"east": {"uv": [6.5, 5, 7, 7], "texture": "#0"},
+				"south": {"uv": [6.5, 5, 7.5, 7], "texture": "#0"},
+				"west": {"uv": [7, 5, 7.5, 7], "texture": "#0"},
+				"up": {"uv": [6.5, 5, 7.5, 5.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [6.5, 6.5, 7.5, 7], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 5, 6],
+			"to": [15, 9, 7],
+			"faces": {
+				"north": {"uv": [0.5, 5, 1.5, 7], "texture": "#0"},
+				"east": {"uv": [0.5, 5, 1, 7], "texture": "#0"},
+				"south": {"uv": [0.5, 5, 1.5, 7], "texture": "#0"},
+				"west": {"uv": [1, 5, 1.5, 7], "texture": "#0"},
+				"up": {"uv": [0.5, 5, 1.5, 5.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [0.5, 6.5, 1.5, 7], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 5, 5],
+			"to": [5, 9, 6],
+			"faces": {
+				"north": {"uv": [5.5, 5, 6.5, 7], "texture": "#0"},
+				"east": {"uv": [5.5, 5, 6, 7], "texture": "#0"},
+				"south": {"uv": [5.5, 5, 6.5, 7], "texture": "#0"},
+				"west": {"uv": [6, 5, 6.5, 7], "texture": "#0"},
+				"up": {"uv": [5.5, 5, 6.5, 5.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [5.5, 6.5, 6.5, 7], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 5, 5],
+			"to": [13, 9, 6],
+			"faces": {
+				"north": {"uv": [2, 5, 3, 7], "texture": "#0"},
+				"east": {"uv": [2, 5, 2.5, 7], "texture": "#0"},
+				"south": {"uv": [2, 5, 3, 7], "texture": "#0"},
+				"west": {"uv": [2.5, 5, 3, 7], "texture": "#0"},
+				"up": {"uv": [2, 5, 3, 5.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2, 6.5, 3, 7], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 5, 4],
+			"to": [11, 9, 5],
+			"faces": {
+				"north": {"uv": [2.5, 5, 5.5, 7], "texture": "#0"},
+				"east": {"uv": [2.5, 5, 3, 7], "texture": "#0"},
+				"south": {"uv": [2.5, 5, 5.5, 7], "texture": "#0"},
+				"west": {"uv": [5, 5, 5.5, 7], "texture": "#0"},
+				"up": {"uv": [2.5, 5, 5.5, 5.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [2.5, 6.5, 5.5, 7], "rotation": 180, "texture": "#0"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"ground": {
+			"translation": [0, 3, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.5, 1.25, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"head": {
+			"translation": [0, 1.25, -6.56],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 1.2, 0],
+			"scale": [0.66, 0.66, 0.66]
+		}
+	},
+	"overrides": [{
+		"predicate": { "blocking": 1 },
+		"model": "tfc:item/metal/shield/red_steel_blocking"
+		}
+	],
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6, 7]
+		}, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/red_steel_blocking.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/red_steel_blocking.json
@@ -1,0 +1,49 @@
+{
+	"credit": "Made with Blockbench",
+	"parent":"tfc:item/metal/shield/red_steel",
+	"textures": {
+		"0": "tfc:item/metal/shield/red_steel",
+		"particle": "tfc:item/metal/shield/red_steel"
+	},
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"firstperson_lefthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"ground": {
+			"translation": [0, 1, 0],
+			"scale": [0.3, 0.3, 0.3]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.5, 1.25, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"head": {
+			"translation": [0, 1.25, -6.56],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 4.25, 0.12],
+			"scale": [2.02, 2.02, 2.02]
+		}
+	},
+	"groups": [
+		{
+			"name": "handle",
+			"origin": [8, 8, 8],
+			"children": [0, 1, 2, 3, 4, 5, 6, 7]
+		}, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/steel.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/steel.json
@@ -1,0 +1,471 @@
+{
+	"credit": "Made with Blockbench",
+	"textures": {
+		"0": "tfc:item/metal/shield/steel",
+		"particle": "tfc:item/metal/shield/steel"
+	},
+	"elements": [
+		{
+			"name": "handle",
+			"from": [9, 6, 12],
+			"to": [10, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 6, 12],
+			"to": [6, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 5, 7],
+			"to": [10, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 5, 7],
+			"to": [6, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [9, 10, 7],
+			"to": [10, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"name": "handle",
+			"from": [5, 10, 7],
+			"to": [6, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#0"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#0"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#0"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"from": [7, -1, 6],
+			"to": [9, 14, 7],
+			"faces": {
+				"north": {"uv": [3.5, 1, 4.5, 8.5], "texture": "#0"},
+				"east": {"uv": [3.5, 1, 4, 8.5], "texture": "#0"},
+				"south": {"uv": [11.5, 1, 12.5, 8.5], "texture": "#0"},
+				"west": {"uv": [4, 1, 4.5, 8.5], "texture": "#0"},
+				"up": {"uv": [3.5, 1, 4.5, 1.5], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [3.5, 7.5, 4.5, 8], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [9, 0, 6],
+			"to": [10, 13, 7],
+			"faces": {
+				"north": {"uv": [3, 1.5, 3.5, 8], "texture": "#0"},
+				"east": {"uv": [3, 1.5, 3.5, 8], "texture": "#0"},
+				"south": {"uv": [12.5, 1.5, 13, 8], "texture": "#0"},
+				"west": {"uv": [3, 1.5, 3.5, 8], "texture": "#0"},
+				"up": {"uv": [3, 1.5, 3.5, 2], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [3, 7.5, 3.5, 8], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [10, 1, 6],
+			"to": [11, 13, 7],
+			"faces": {
+				"north": {"uv": [2.5, 1.5, 3, 7.5], "texture": "#0"},
+				"east": {"uv": [2.5, 1.5, 3, 7.5], "texture": "#0"},
+				"south": {"uv": [13, 1.5, 13.5, 7.5], "texture": "#0"},
+				"west": {"uv": [2.5, 1.5, 3, 7.5], "texture": "#0"},
+				"up": {"uv": [2.5, 1.5, 3, 2], "texture": "#0"},
+				"down": {"uv": [2.5, 7, 3, 7.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 2, 6],
+			"to": [12, 13, 7],
+			"faces": {
+				"north": {"uv": [2, 1.5, 2.5, 7], "texture": "#0"},
+				"east": {"uv": [2, 1.5, 2.5, 7], "texture": "#0"},
+				"south": {"uv": [13.5, 1.5, 14, 7], "texture": "#0"},
+				"west": {"uv": [2, 1.5, 2.5, 7], "texture": "#0"},
+				"up": {"uv": [2, 1.5, 2.5, 2], "texture": "#0"},
+				"down": {"uv": [2, 6.5, 2.5, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [12, 4, 6],
+			"to": [13, 14, 7],
+			"faces": {
+				"north": {"uv": [1.5, 1, 2, 6], "texture": "#0"},
+				"east": {"uv": [1.5, 1, 2, 6], "texture": "#0"},
+				"south": {"uv": [14, 1, 14.5, 6], "texture": "#0"},
+				"west": {"uv": [1.5, 1, 2, 6], "texture": "#0"},
+				"up": {"uv": [1.5, 1, 2, 1.5], "texture": "#0"},
+				"down": {"uv": [1.5, 5.5, 2, 6], "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 7, 6],
+			"to": [14, 14, 7],
+			"faces": {
+				"north": {"uv": [1, 1, 1.5, 4.5], "texture": "#0"},
+				"east": {"uv": [1, 1, 1.5, 4.5], "texture": "#0"},
+				"south": {"uv": [14.5, 1, 15, 4.5], "texture": "#0"},
+				"west": {"uv": [1, 1, 1.5, 4.5], "texture": "#0"},
+				"up": {"uv": [1, 1, 1.5, 1.5], "texture": "#0"},
+				"down": {"uv": [1, 4, 1.5, 4.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [13, 7, 7],
+			"to": [15, 15, 8],
+			"faces": {
+				"north": {"uv": [0.5, 0.5, 1.5, 4.5], "texture": "#0"},
+				"east": {"uv": [0.5, 0.5, 1, 4.5], "texture": "#0"},
+				"south": {"uv": [14.5, 0.5, 15.5, 4.5], "texture": "#0"},
+				"west": {"uv": [14.5, 0.5, 15, 4.5], "texture": "#0"},
+				"up": {"uv": [0.5, 0.5, 1.5, 1], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [0.5, 4, 1.5, 4.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [1, 7, 7],
+			"to": [3, 15, 8],
+			"faces": {
+				"north": {"uv": [6.5, 0.5, 7.5, 4.5], "texture": "#0"},
+				"east": {"uv": [9, 0.5, 9.5, 4.5], "texture": "#0"},
+				"south": {"uv": [8.5, 0.5, 9.5, 4.5], "texture": "#0"},
+				"west": {"uv": [7, 0.5, 7.5, 4.5], "texture": "#0"},
+				"up": {"uv": [6.5, 0.5, 7.5, 1], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [6.5, 4, 7.5, 4.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 7, 6],
+			"to": [3, 14, 7],
+			"faces": {
+				"north": {"uv": [6.5, 1, 7, 4.5], "texture": "#0"},
+				"east": {"uv": [6.5, 1, 7, 4.5], "texture": "#0"},
+				"south": {"uv": [9, 1, 9.5, 4.5], "texture": "#0"},
+				"west": {"uv": [6.5, 1, 7, 4.5], "texture": "#0"},
+				"up": {"uv": [6.5, 1, 7, 1.5], "texture": "#0"},
+				"down": {"uv": [6.5, 4, 7, 4.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 4, 6],
+			"to": [4, 14, 7],
+			"faces": {
+				"north": {"uv": [6, 1, 6.5, 6], "texture": "#0"},
+				"east": {"uv": [6, 1, 6.5, 6], "texture": "#0"},
+				"south": {"uv": [9.5, 1, 10, 6], "texture": "#0"},
+				"west": {"uv": [6, 1, 6.5, 6], "texture": "#0"},
+				"up": {"uv": [6, 1, 6.5, 1.5], "texture": "#0"},
+				"down": {"uv": [6, 5.5, 6.5, 6], "texture": "#0"}
+			}
+		},
+		{
+			"from": [4, 2, 6],
+			"to": [5, 13, 7],
+			"faces": {
+				"north": {"uv": [5.5, 1.5, 6, 7], "texture": "#0"},
+				"east": {"uv": [5.5, 1.5, 6, 7], "texture": "#0"},
+				"south": {"uv": [10, 1.5, 10.5, 7], "texture": "#0"},
+				"west": {"uv": [5.5, 1.5, 6, 7], "texture": "#0"},
+				"up": {"uv": [5.5, 1.5, 6, 2], "texture": "#0"},
+				"down": {"uv": [5.5, 6.5, 6, 7], "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 1, 6],
+			"to": [6, 13, 7],
+			"faces": {
+				"north": {"uv": [5, 1.5, 5.5, 7.5], "texture": "#0"},
+				"east": {"uv": [5, 1.5, 5.5, 7.5], "texture": "#0"},
+				"south": {"uv": [10.5, 1.5, 11, 7.5], "texture": "#0"},
+				"west": {"uv": [5, 1.5, 5.5, 7.5], "texture": "#0"},
+				"up": {"uv": [5, 1.5, 5.5, 2], "texture": "#0"},
+				"down": {"uv": [5, 7, 5.5, 7.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [6, 0, 6],
+			"to": [7, 13, 7],
+			"faces": {
+				"north": {"uv": [4.5, 1.5, 5, 8], "texture": "#0"},
+				"east": {"uv": [4.5, 1.5, 5, 8], "texture": "#0"},
+				"south": {"uv": [11, 1.5, 11.5, 8], "texture": "#0"},
+				"west": {"uv": [4.5, 1.5, 5, 8], "texture": "#0"},
+				"up": {"uv": [4.5, 1.5, 5, 2], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [4.5, 7.5, 5, 8], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 6, 7],
+			"to": [13, 10, 8],
+			"faces": {
+				"north": {"uv": [9.5, 3, 14.5, 5], "texture": "#0"},
+				"east": {"uv": [14, 3, 14.5, 5], "texture": "#0"},
+				"south": {"uv": [9.5, 3, 14.5, 5], "texture": "#0"},
+				"west": {"uv": [9.5, 3, 10, 5], "texture": "#0"},
+				"up": {"uv": [9.5, 3, 14.5, 3.5], "texture": "#0"},
+				"down": {"uv": [9.5, 4.5, 14.5, 5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [9, 12, 7],
+			"to": [12, 14, 8],
+			"faces": {
+				"north": {"uv": [2, 1, 3.5, 2], "texture": "#0"},
+				"east": {"uv": [13.5, 1, 14, 2], "texture": "#0"},
+				"south": {"uv": [12.5, 1, 14, 2], "texture": "#0"},
+				"west": {"uv": [12.5, 1, 13, 2], "texture": "#0"},
+				"up": {"uv": [2, 1, 3.5, 1.5], "texture": "#0"},
+				"down": {"uv": [12.5, 1.5, 14, 2], "texture": "#0"}
+			}
+		},
+		{
+			"from": [4, 12, 7],
+			"to": [7, 14, 8],
+			"faces": {
+				"north": {"uv": [4.5, 1, 6, 2], "texture": "#0"},
+				"east": {"uv": [11, 1, 11.5, 2], "texture": "#0"},
+				"south": {"uv": [10, 1, 11.5, 2], "texture": "#0"},
+				"west": {"uv": [10, 1, 10.5, 2], "texture": "#0"},
+				"up": {"uv": [4.5, 1, 6, 1.5], "texture": "#0"},
+				"down": {"uv": [10, 1.5, 11.5, 2], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [7, 13, 7],
+			"to": [9, 15, 8],
+			"faces": {
+				"north": {"uv": [3.5, 0.5, 4.5, 1.5], "texture": "#0"},
+				"east": {"uv": [3.5, 0.5, 4, 1.5], "texture": "#0"},
+				"south": {"uv": [11.5, 0.5, 12.5, 1.5], "texture": "#0"},
+				"west": {"uv": [4, 0.5, 4.5, 1.5], "texture": "#0"},
+				"up": {"uv": [3.5, 0.5, 4.5, 1], "rotation": 180, "texture": "#0"},
+				"down": {"uv": [11.5, 1, 12.5, 1.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [12, 13, 7],
+			"to": [13, 15, 8],
+			"faces": {
+				"north": {"uv": [1.5, 0.5, 2, 1.5], "texture": "#0"},
+				"east": {"uv": [1.5, 0.5, 2, 1.5], "texture": "#0"},
+				"south": {"uv": [14, 0.5, 14.5, 1.5], "texture": "#0"},
+				"west": {"uv": [1.5, 0.5, 2, 1.5], "texture": "#0"},
+				"up": {"uv": [1.5, 0.5, 2, 1], "texture": "#0"},
+				"down": {"uv": [14, 1, 14.5, 1.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 13, 7],
+			"to": [4, 15, 8],
+			"faces": {
+				"north": {"uv": [6, 0.5, 6.5, 1.5], "texture": "#0"},
+				"east": {"uv": [6, 0.5, 6.5, 1.5], "texture": "#0"},
+				"south": {"uv": [9.5, 0.5, 10, 1.5], "texture": "#0"},
+				"west": {"uv": [6, 0.5, 6.5, 1.5], "texture": "#0"},
+				"up": {"uv": [6, 0.5, 6.5, 1], "texture": "#0"},
+				"down": {"uv": [9.5, 1, 10, 1.5], "texture": "#0"}
+			}
+		},
+		{
+			"from": [12, 4, 7],
+			"to": [14, 7, 8],
+			"faces": {
+				"north": {"uv": [1, 4.5, 2, 6], "texture": "#0"},
+				"east": {"uv": [1, 4.5, 1.5, 6], "texture": "#0"},
+				"south": {"uv": [14, 4.5, 15, 6], "texture": "#0"},
+				"west": {"uv": [14, 4.5, 14.5, 6], "texture": "#0"},
+				"up": {"uv": [1, 4.5, 2, 5], "texture": "#0"},
+				"down": {"uv": [1, 5.5, 2, 6], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [2, 4, 7],
+			"to": [4, 7, 8],
+			"faces": {
+				"north": {"uv": [6, 4.5, 7, 6], "texture": "#0"},
+				"east": {"uv": [9.5, 4.5, 10, 6], "texture": "#0"},
+				"south": {"uv": [9, 4.5, 10, 6], "texture": "#0"},
+				"west": {"uv": [6.5, 4.5, 7, 6], "texture": "#0"},
+				"up": {"uv": [1, 4.5, 2, 5], "texture": "#0"},
+				"down": {"uv": [6, 5.5, 7, 6], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [3, 2, 7],
+			"to": [5, 4, 8],
+			"faces": {
+				"north": {"uv": [5.5, 6, 6.5, 7], "texture": "#0"},
+				"east": {"uv": [10, 6, 10.5, 7], "texture": "#0"},
+				"south": {"uv": [9.5, 6, 10.5, 7], "texture": "#0"},
+				"west": {"uv": [6, 6, 6.5, 7], "texture": "#0"},
+				"up": {"uv": [9.5, 6, 10.5, 6.5], "texture": "#0"},
+				"down": {"uv": [5.5, 6.5, 6.5, 7], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [11, 2, 7],
+			"to": [13, 4, 8],
+			"faces": {
+				"north": {"uv": [1.5, 6, 2.5, 7], "texture": "#0"},
+				"east": {"uv": [1.5, 6, 2, 7], "texture": "#0"},
+				"south": {"uv": [13.5, 6, 14.5, 7], "texture": "#0"},
+				"west": {"uv": [13.5, 6, 14, 7], "texture": "#0"},
+				"up": {"uv": [13.5, 6, 14.5, 6.5], "texture": "#0"},
+				"down": {"uv": [1.5, 6.5, 2.5, 7], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [10, 1, 7],
+			"to": [12, 2, 8],
+			"faces": {
+				"north": {"uv": [2, 7, 3, 7.5], "texture": "#0"},
+				"east": {"uv": [2, 7, 2.5, 7.5], "texture": "#0"},
+				"south": {"uv": [13, 7, 14, 7.5], "texture": "#0"},
+				"west": {"uv": [13, 7, 13.5, 7.5], "texture": "#0"},
+				"up": {"uv": [13, 7, 14, 7.5], "texture": "#0"},
+				"down": {"uv": [2, 7, 3, 7.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [9, 0, 7],
+			"to": [11, 1, 8],
+			"faces": {
+				"north": {"uv": [2.5, 7.5, 3.5, 8], "texture": "#0"},
+				"east": {"uv": [2.5, 7.5, 3, 8], "texture": "#0"},
+				"south": {"uv": [12.5, 7.5, 13.5, 8], "texture": "#0"},
+				"west": {"uv": [12.5, 7.5, 13, 8], "texture": "#0"},
+				"up": {"uv": [12.5, 7.5, 13.5, 8], "texture": "#0"},
+				"down": {"uv": [2.5, 7.5, 3.5, 8], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [4, 1, 7],
+			"to": [6, 2, 8],
+			"faces": {
+				"north": {"uv": [5, 7, 6, 7.5], "texture": "#0"},
+				"east": {"uv": [10.5, 7, 11, 7.5], "texture": "#0"},
+				"south": {"uv": [10, 7, 11, 7.5], "texture": "#0"},
+				"west": {"uv": [2, 7, 2.5, 7.5], "texture": "#0"},
+				"up": {"uv": [10, 7, 11, 7.5], "texture": "#0"},
+				"down": {"uv": [5, 7, 6, 7.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5, 0, 7],
+			"to": [7, 1, 8],
+			"faces": {
+				"north": {"uv": [4.5, 7.5, 5.5, 8], "texture": "#0"},
+				"east": {"uv": [11, 7.5, 11.5, 8], "texture": "#0"},
+				"south": {"uv": [10.5, 7.5, 11.5, 8], "texture": "#0"},
+				"west": {"uv": [2.5, 7.5, 3, 8], "texture": "#0"},
+				"up": {"uv": [10.5, 7.5, 11.5, 8], "texture": "#0"},
+				"down": {"uv": [4.5, 7.5, 5.5, 8], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [6, -1, 7],
+			"to": [10, 0, 8],
+			"faces": {
+				"north": {"uv": [3, 8, 5, 8.5], "texture": "#0"},
+				"east": {"uv": [3, 8, 3.5, 8.5], "texture": "#0"},
+				"south": {"uv": [11, 8, 13, 8.5], "texture": "#0"},
+				"west": {"uv": [4.5, 8, 5, 8.5], "texture": "#0"},
+				"up": {"uv": [11, 8, 13, 8.5], "texture": "#0"},
+				"down": {"uv": [3, 8, 5, 8.5], "rotation": 180, "texture": "#0"}
+			}
+		},
+		{
+			"from": [7, -2, 7],
+			"to": [9, -1, 8],
+			"faces": {
+				"north": {"uv": [3.5, 8.5, 4.5, 9], "texture": "#0"},
+				"east": {"uv": [3.5, 8.5, 4, 9], "texture": "#0"},
+				"south": {"uv": [11.5, 8.5, 12.5, 9], "texture": "#0"},
+				"west": {"uv": [4, 8.5, 4.5, 9], "texture": "#0"},
+				"up": {"uv": [3.5, 8.5, 4.5, 9], "texture": "#0"},
+				"down": {"uv": [3.5, 8.5, 4.5, 9], "rotation": 180, "texture": "#0"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"ground": {
+			"translation": [0, 3, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.25, 0.75, 0],
+			"scale": [0.65, 0.65, 0.65]
+		},
+		"head": {
+			"translation": [0, 0.75, -7.25],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 0.5, 0],
+			"scale": [0.75, 0.75, 0.75]
+		}
+	},
+	"overrides": [{
+		"predicate": { "blocking": 1 },
+		"model": "tfc:item/metal/shield/steel_blocking"
+		}
+	]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/steel_blocking.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/steel_blocking.json
@@ -1,0 +1,39 @@
+{
+	"credit": "Made with Blockbench",
+	"parent":"tfc:item/metal/shield/steel",
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"firstperson_lefthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"ground": {
+			"translation": [0, 3, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.25, 0.75, 0],
+			"scale": [0.65, 0.65, 0.65]
+		},
+		"head": {
+			"translation": [0, 0.75, -7.25],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 0, -0.38],
+			"scale": [2.02, 2.02, 2.02]
+		}
+	}
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/wrought_iron.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/wrought_iron.json
@@ -1,0 +1,324 @@
+{
+	"credit": "Made with Blockbench",
+	"textures": {
+		"texture": "tfc:item/metal/shield/wrought_iron"
+	},
+	"elements": [
+		{
+			"from": [5, 10, 7],
+			"to": [6, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#texture"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#texture"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#texture"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#texture"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#texture"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#texture"}
+			}
+		},
+		{
+			"from": [9, 10, 7],
+			"to": [10, 11, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#texture"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#texture"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#texture"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#texture"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#texture"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#texture"}
+			}
+		},
+		{
+			"from": [5, 5, 7],
+			"to": [6, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#texture"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#texture"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#texture"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#texture"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#texture"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#texture"}
+			}
+		},
+		{
+			"from": [9, 5, 7],
+			"to": [10, 6, 13],
+			"faces": {
+				"north": {"uv": [6.5, 14, 7, 14.5], "texture": "#texture"},
+				"east": {"uv": [6.5, 14, 9.5, 14.5], "texture": "#texture"},
+				"south": {"uv": [6.5, 14, 7, 14.5], "texture": "#texture"},
+				"west": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 180, "texture": "#texture"},
+				"up": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 270, "texture": "#texture"},
+				"down": {"uv": [6.5, 14, 9.5, 14.5], "rotation": 90, "texture": "#texture"}
+			}
+		},
+		{
+			"from": [5, 6, 12],
+			"to": [6, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#texture"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#texture"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#texture"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#texture"}
+			}
+		},
+		{
+			"from": [9, 6, 12],
+			"to": [10, 10, 13],
+			"faces": {
+				"north": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#texture"},
+				"east": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#texture"},
+				"south": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#texture"},
+				"west": {"uv": [7, 14, 9, 14.5], "rotation": 90, "texture": "#texture"}
+			}
+		},
+		{
+			"name": "board",
+			"from": [3, 6, 7],
+			"to": [13, 10, 8],
+			"faces": {
+				"north": {"uv": [1, 14, 6, 16], "texture": "#texture"},
+				"east": {"uv": [12, 0.5, 12.5, 1], "texture": "#texture"},
+				"south": {"uv": [1, 14, 6, 16], "texture": "#texture"},
+				"west": {"uv": [12.5, 0.5, 13, 1], "texture": "#texture"},
+				"up": {"uv": [6, 14.5, 1, 14], "rotation": 180, "texture": "#texture"},
+				"down": {"uv": [6, 16, 1, 15.5], "texture": "#texture"}
+			}
+		},
+		{
+			"name": "center",
+			"from": [7, -6, 6],
+			"to": [9, 17, 7],
+			"faces": {
+				"north": {"uv": [3.5, 0.5, 4.5, 12], "texture": "#texture"},
+				"east": {"uv": [3.5, 0.5, 4, 12], "texture": "#texture"},
+				"south": {"uv": [11.5, 0.5, 12.5, 12], "texture": "#texture"},
+				"west": {"uv": [4, 0.5, 4.5, 12], "texture": "#texture"},
+				"up": {"uv": [3.5, 0.5, 4.5, 1], "rotation": 180, "texture": "#texture"},
+				"down": {"uv": [11.5, 11.5, 12.5, 12], "texture": "#texture"}
+			}
+		},
+		{
+			"name": "center",
+			"from": [5, -3, 6],
+			"to": [7, 17, 7],
+			"faces": {
+				"north": {"uv": [4.5, 0.5, 5.5, 10.5], "texture": "#texture"},
+				"south": {"uv": [10.5, 0.5, 11.5, 10.5], "texture": "#texture"},
+				"west": {"uv": [5, 0.5, 5.5, 10.5], "texture": "#texture"},
+				"up": {"uv": [4.5, 0.5, 5.5, 1], "texture": "#texture"},
+				"down": {"uv": [10.5, 10, 11.5, 10.5], "texture": "#texture"}
+			}
+		},
+		{
+			"name": "center",
+			"from": [6, -5, 6],
+			"to": [7, -3, 7],
+			"faces": {
+				"north": {"uv": [4.5, 10.5, 5, 11.5], "texture": "#texture"},
+				"east": {"uv": [0, 0, 1, 2], "texture": "#texture"},
+				"south": {"uv": [11, 10.5, 11.5, 11.5], "texture": "#texture"},
+				"west": {"uv": [4.5, 10.5, 5, 11.5], "texture": "#texture"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#texture"},
+				"down": {"uv": [11, 11, 11.5, 11.5], "texture": "#texture"}
+			}
+		},
+		{
+			"name": "center",
+			"from": [9, -5, 6],
+			"to": [10, -3, 7],
+			"faces": {
+				"north": {"uv": [3, 10.5, 3.5, 11.5], "texture": "#texture"},
+				"east": {"uv": [3, 10.5, 3.5, 11.5], "texture": "#texture"},
+				"south": {"uv": [12.5, 10.5, 13, 11.5], "texture": "#texture"},
+				"west": {"uv": [0, 0, 1, 2], "texture": "#texture"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#texture"},
+				"down": {"uv": [12.5, 11, 13, 11.5], "texture": "#texture"}
+			}
+		},
+		{
+			"name": "center",
+			"from": [9, -3, 6],
+			"to": [11, 17, 7],
+			"faces": {
+				"north": {"uv": [2.5, 0.5, 3.5, 10.5], "texture": "#texture"},
+				"east": {"uv": [2.5, 0.5, 3, 10.5], "texture": "#texture"},
+				"south": {"uv": [12.5, 0.5, 13.5, 10.5], "texture": "#texture"},
+				"up": {"uv": [2.5, 0.5, 3.5, 1], "texture": "#texture"},
+				"down": {"uv": [12.5, 10, 13.5, 10.5], "texture": "#texture"}
+			}
+		},
+		{
+			"name": "outside",
+			"from": [11, 0, 6],
+			"to": [12, 3, 7],
+			"faces": {
+				"north": {"uv": [2.5, 9, 3, 10.5], "texture": "#texture"},
+				"east": {"uv": [2.5, 9, 3, 10.5], "texture": "#texture"},
+				"south": {"uv": [13.5, 7.5, 14, 9], "texture": "#texture"},
+				"west": {"uv": [13.5, 7.5, 14, 9], "texture": "#texture"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#texture"},
+				"down": {"uv": [2.5, 10, 3, 10.5], "texture": "#texture"}
+			}
+		},
+		{
+			"name": "outside",
+			"from": [4, 0, 6],
+			"to": [5, 3, 7],
+			"faces": {
+				"north": {"uv": [5, 9, 5.5, 10.5], "texture": "#texture"},
+				"east": {"uv": [10, 7.5, 10.5, 9], "texture": "#texture"},
+				"south": {"uv": [10.5, 9, 11, 10.5], "texture": "#texture"},
+				"west": {"uv": [5.5, 7.5, 6, 9], "texture": "#texture"},
+				"up": {"uv": [0, 0, 1, 1], "texture": "#texture"},
+				"down": {"uv": [5.5, 8.5, 6, 9], "texture": "#texture"}
+			}
+		},
+		{
+			"name": "outside",
+			"from": [3, 3, 6],
+			"to": [5, 16, 7],
+			"faces": {
+				"north": {"uv": [5.5, 1, 6.5, 7.5], "texture": "#texture"},
+				"east": {"uv": [10, 1, 10.5, 7.5], "texture": "#texture"},
+				"south": {"uv": [9.5, 1, 10.5, 7.5], "texture": "#texture"},
+				"west": {"uv": [6, 1, 6.5, 7.5], "texture": "#texture"},
+				"up": {"uv": [5.5, 1, 6.5, 1.5], "texture": "#texture"},
+				"down": {"uv": [9.5, 7, 10.5, 7.5], "texture": "#texture"}
+			}
+		},
+		{
+			"name": "outside",
+			"from": [2, 5, 7],
+			"to": [3, 15, 8],
+			"faces": {
+				"north": {"uv": [6.5, 1.5, 7, 6.5], "texture": "#texture"},
+				"east": {"uv": [9, 1.5, 9.5, 6.5], "texture": "#texture"},
+				"south": {"uv": [9, 1.5, 9.5, 6.5], "texture": "#texture"},
+				"west": {"uv": [6.5, 1.5, 7, 6.5], "texture": "#texture"},
+				"up": {"uv": [6.5, 1.5, 7, 2], "texture": "#texture"},
+				"down": {"uv": [6.5, 6, 7, 6.5], "texture": "#texture"}
+			}
+		},
+		{
+			"name": "outside",
+			"from": [1, 9, 7],
+			"to": [2, 14, 8],
+			"faces": {
+				"north": {"uv": [7, 2, 7.5, 4.5], "texture": "#texture"},
+				"east": {"uv": [0, 0, 1, 5], "texture": "#texture"},
+				"south": {"uv": [8.5, 2, 9, 4.5], "texture": "#texture"},
+				"west": {"uv": [7, 2, 7.5, 4.5], "texture": "#texture"},
+				"up": {"uv": [7, 2, 7.5, 2.5], "texture": "#texture"},
+				"down": {"uv": [7, 4, 7.5, 4.5], "texture": "#texture"}
+			}
+		},
+		{
+			"name": "outside",
+			"from": [11, 3, 6],
+			"to": [13, 16, 7],
+			"faces": {
+				"north": {"uv": [1.5, 1, 2.5, 7.5], "texture": "#texture"},
+				"east": {"uv": [1.5, 1, 2, 7.5], "texture": "#texture"},
+				"south": {"uv": [13.5, 1, 14.5, 7.5], "texture": "#texture"},
+				"west": {"uv": [13.5, 1, 14, 7.5], "texture": "#texture"},
+				"up": {"uv": [1.5, 1, 2.5, 1.5], "texture": "#texture"},
+				"down": {"uv": [13, 8.5, 14, 9], "rotation": 180, "texture": "#texture"}
+			}
+		},
+		{
+			"name": "outside",
+			"from": [13, 5, 7],
+			"to": [14, 15, 8],
+			"faces": {
+				"north": {"uv": [1, 1.5, 1.5, 6.5], "texture": "#texture"},
+				"east": {"uv": [1, 1.5, 1.5, 6.5], "texture": "#texture"},
+				"south": {"uv": [14.5, 1.5, 15, 6.5], "texture": "#texture"},
+				"west": {"uv": [14.5, 1.5, 15, 6.5], "texture": "#texture"},
+				"up": {"uv": [1, 1.5, 1.5, 2], "texture": "#texture"},
+				"down": {"uv": [1, 6, 1.5, 6.5], "texture": "#texture"}
+			}
+		},
+		{
+			"name": "outside",
+			"from": [14, 9, 7],
+			"to": [15, 14, 8],
+			"faces": {
+				"north": {"uv": [0.5, 2, 1, 4.5], "texture": "#texture"},
+				"east": {"uv": [0.5, 2, 1, 4.5], "texture": "#texture"},
+				"south": {"uv": [15, 2, 15.5, 4.5], "texture": "#texture"},
+				"west": {"uv": [0, 0, 1, 4], "texture": "#texture"},
+				"up": {"uv": [0.5, 2, 1, 2.5], "texture": "#texture"},
+				"down": {"uv": [0.5, 4, 1, 4.5], "texture": "#texture"}
+			}
+		},
+		{
+			"from": [2, 9, 6],
+			"to": [3, 14, 7],
+			"faces": {
+				"north": {"uv": [6.5, 2, 7, 4.5], "texture": "#texture"},
+				"east": {"uv": [6.5, 2, 7, 4.5], "texture": "#texture"},
+				"south": {"uv": [6.5, 2, 7, 4.5], "texture": "#texture"},
+				"west": {"uv": [6.5, 2, 7, 4.5], "texture": "#texture"},
+				"up": {"uv": [6.5, 2, 7, 2.5], "texture": "#texture"},
+				"down": {"uv": [6.5, 4, 7, 4.5], "texture": "#texture"}
+			}
+		},
+		{
+			"from": [13, 9, 6],
+			"to": [14, 14, 7],
+			"faces": {
+				"north": {"uv": [1, 2, 1.5, 4.5], "texture": "#texture"},
+				"east": {"uv": [1, 2, 1.5, 4.5], "texture": "#texture"},
+				"south": {"uv": [1, 2, 1.5, 4.5], "texture": "#texture"},
+				"west": {"uv": [1, 2, 1.5, 4.5], "texture": "#texture"},
+				"up": {"uv": [1, 2, 1.5, 2.5], "texture": "#texture"},
+				"down": {"uv": [1, 4, 1.5, 4.5], "texture": "#texture"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, -75, 15],
+			"translation": [4, -4, 0]
+		},
+		"ground": {
+			"translation": [0, 3, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.5, 1.5, 0],
+			"scale": [0.65, 0.65, 0.65]
+		},
+		"head": {
+			"rotation": [90, 0, -180],
+			"translation": [0, 5.5, -1.31],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 1.5, 0],
+			"scale": [0.66, 0.66, 0.66]
+		}
+	},
+	"overrides": [
+        {
+            "predicate": {
+                "blocking": 1
+            },
+            "model": "tfc:item/metal/shield/wrought_iron_blocking"
+        }
+    ]
+}

--- a/kubejs/assets/tfc/models/item/metal/shield/wrought_iron_blocking.json
+++ b/kubejs/assets/tfc/models/item/metal/shield/wrought_iron_blocking.json
@@ -1,0 +1,43 @@
+{
+	"credit": "Made with Blockbench",
+	"parent":"tfc:item/metal/shield/wrought_iron",
+	"textures": {
+		"texture": "tfc:item/metal/shield/wrought_iron"
+	},
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, 0],
+			"translation": [2.3, -2, 5]
+		},
+		"firstperson_righthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"firstperson_lefthand": {
+			"rotation": [5, -30, 5],
+			"translation": [-1.5, 0.5, 2.5]
+		},
+		"ground": {
+			"translation": [0, 3, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [30, 145, 0],
+			"translation": [0.5, 1.5, 0],
+			"scale": [0.65, 0.65, 0.65]
+		},
+		"head": {
+			"rotation": [90, 0, -180],
+			"translation": [0, 5.5, -1.31],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"translation": [0, 0, -0.38],
+			"scale": [2.02, 2.02, 2.02]
+		}
+	}
+}


### PR DESCRIPTION
## What is the new behavior?
See before in linked issue (#4050)

After:
<img width="335" height="504" alt="2026-06-22_17 52 15" src="https://github.com/user-attachments/assets/a2660fcc-44d3-4c69-8d37-dc62fcf705fe" />
<img width="717" height="810" alt="2026-06-22_17 53 34" src="https://github.com/user-attachments/assets/27afd311-8ad9-425f-85be-50848960b3d1" />

Also updates the models of other TFC shields to match the Vexxed Visuals textures already included in the kubejs/assets folder. These additional before and after comparisons are shown in this image:
<img width="2431" height="928" alt="shields_before after" src="https://github.com/user-attachments/assets/4d61013d-7588-49b7-bd55-63ed0bc950b2" />

This also improves color consistency when paired with the corresponding armor sets.

## Implementation Details
Copied the model .json files for all shields from Vexxed Visuals v1.2.7.1 into the kubejs/assets folder so that the Vexxed Visuals textures appear as intended.


## Outcome
Fixes #4050 and makes shields actually use the Vexxed Visuals textures included in the kubejs/assets folder