### PR TITLE
Fix purified tin and silver producing blacklisted TFC ingots

### DIFF
--- a/kubejs/server_scripts/create/recipes.js
+++ b/kubejs/server_scripts/create/recipes.js
@@ -2421,8 +2421,8 @@ const registerCreateRecipes = (event) => {
 	event.smelting('#forge:ingots/copper', 'create:crushed_raw_copper')
 	event.smelting('#forge:ingots/gold', 'create:crushed_raw_gold')
 	event.smelting('#forge:ingots/zinc', 'create:crushed_raw_zinc')
-	event.smelting('#forge:ingots/silver', 'create:crushed_raw_silver')
-	event.smelting('#forge:ingots/tin', 'create:crushed_raw_tin')
+	event.smelting('gtceu:silver_ingot', 'create:crushed_raw_silver')
+	event.smelting('gtceu:tin_ingot', 'create:crushed_raw_tin')
 	event.smelting('#forge:ingots/lead', 'create:crushed_raw_lead')
 
 }


### PR DESCRIPTION
## What is the new behavior?
Relevant issue: #4359 
Purified silver and tin now produce correct GT ingots instead of blacklisted TFC ones.

## Implementation Details
Changes the furnace recipes for purified silver and tin to explicitly produce gtceu:silver_ingot/tin_ingot instead of referencing the forge ingot tag.

## Outcome
Fixes: #4359 

## Additional Information
I cannot be 100% certain this bug is not due to some weird issue with my installation, though it shouldn't be as I have tried on two separate fresh installs. **This should be replicated first before merging**.

## Potential Compatibility Issues
I am unsure of the ramifications of switching the furnace recipe over to explicitly provide GT ingots, e.g. if the ingot is changed in the future to another mod's ingot, it would not properly switch over. I am personally unsure if there is another way to fix this issue, ideally the recipe would still reference the tag but the tag would properly exclude the TFC ingots.

Discord username: CaptainGold1