### PR TITLE
Fix Channel Casting Clay Recycling

### DIFF
--- a/kubejs/server_scripts/main_server_script.js
+++ b/kubejs/server_scripts/main_server_script.js
@@ -43,6 +43,7 @@ ServerEvents.tags('item', event => {
 	registerSNSItemTags(event)
 	registerSpeciesItemTags(event)
 	registerTACZItemTags(event)
+	registerTFCChannelCastingItemTags(event)
 	registerTFCItemTags(event)
 	registerTFCScrapingKnivesItemTags(event)
 	registerTFGItemTags(event)

--- a/kubejs/server_scripts/tfcchannelcasting/tags.js
+++ b/kubejs/server_scripts/tfcchannelcasting/tags.js
@@ -1,0 +1,12 @@
+"use strict";
+
+const registerTFCChannelCastingItemTags = (event) => {
+
+	event.remove('tfcchannelcasting:fire_clay_recycle_5', `tfcchannelcasting:unfired_mold_table`)
+	event.remove('tfcchannelcasting:fire_clay_recycle_1', `tfcchannelcasting:unfired_channel`)
+	event.remove('tfcchannelcasting:clay_recycle_5', `tfcchannelcasting:unfired_heart_mold`)
+	event.add('tfc:fire_clay_recycle_5', `tfcchannelcasting:unfired_mold_table`)
+	event.add('tfc:fire_clay_recycle_1', `tfcchannelcasting:unfired_channel`)
+	event.add('tfc:clay_recycle_5', `tfcchannelcasting:unfired_heart_mold`)
+	
+}


### PR DESCRIPTION
Quick fix because the recycling recipe for unfired channel casting items was broken. Removed the TFCChannelCasting tags and replaced them with TFC tags.