### PR TITLE
Feature/digger helmet quest

### DIFF
--- a/config/ftbquests/quests/chapters/tips__tools.snbt
+++ b/config/ftbquests/quests/chapters/tips__tools.snbt
@@ -2324,7 +2324,7 @@
 						"ftbfiltersystem:filter": "or(item(diggerhelmet:digger_helmet)item(diggerhelmet:copper_digger_helmet)item(diggerhelmet:bismuth_bronze_digger_helmet)item(diggerhelmet:black_bronze_digger_helmet)item(diggerhelmet:bronze_digger_helmet)item(diggerhelmet:wrought_iron_digger_helmet)item(diggerhelmet:steel_digger_helmet)item(diggerhelmet:black_steel_digger_helmet)item(diggerhelmet:blue_steel_digger_helmet)item(diggerhelmet:red_steel_digger_helmet))"
 					}
 				}
-				title: "Any Digger Helmet"
+				title: "{quests.tfg_tips.digger_helmet.task}"
 				type: "item"
 			}]
 			title: "{quests.tfg_tips.digger_helmet.title}"

--- a/config/ftbquests/quests/chapters/tips__tools.snbt
+++ b/config/ftbquests/quests/chapters/tips__tools.snbt
@@ -2316,12 +2316,12 @@
 			id: "4425519187BF28FE"
 			subtitle: "{quests.tfg_tips.digger_helmet.subtitle}"
 			tasks: [{
-				id: "6010870D09DAD473"
+				id: "25D97237B649797B"
 				item: {
 					Count: 1
-					id: "diggerhelmet:digger_helmet"
+					id: "ftbfiltersystem:smart_filter"
 					tag: {
-						Damage: 0
+						"ftbfiltersystem:filter": "or(item(diggerhelmet:digger_helmet)item(diggerhelmet:copper_digger_helmet)item(diggerhelmet:bismuth_bronze_digger_helmet)item(diggerhelmet:black_bronze_digger_helmet)item(diggerhelmet:bronze_digger_helmet)item(diggerhelmet:wrought_iron_digger_helmet)item(diggerhelmet:steel_digger_helmet)item(diggerhelmet:black_steel_digger_helmet)item(diggerhelmet:blue_steel_digger_helmet)item(diggerhelmet:red_steel_digger_helmet))"
 					}
 				}
 				type: "item"

--- a/config/ftbquests/quests/chapters/tips__tools.snbt
+++ b/config/ftbquests/quests/chapters/tips__tools.snbt
@@ -2324,6 +2324,7 @@
 						"ftbfiltersystem:filter": "or(item(diggerhelmet:digger_helmet)item(diggerhelmet:copper_digger_helmet)item(diggerhelmet:bismuth_bronze_digger_helmet)item(diggerhelmet:black_bronze_digger_helmet)item(diggerhelmet:bronze_digger_helmet)item(diggerhelmet:wrought_iron_digger_helmet)item(diggerhelmet:steel_digger_helmet)item(diggerhelmet:black_steel_digger_helmet)item(diggerhelmet:blue_steel_digger_helmet)item(diggerhelmet:red_steel_digger_helmet))"
 					}
 				}
+				title: "Any Digger Helmet"
 				type: "item"
 			}]
 			title: "{quests.tfg_tips.digger_helmet.title}"


### PR DESCRIPTION
## What is the new behavior?
Adds all 10 digger helmets to be acceptable inputs for the digger helmet quest.

## Outcome
Fixes: #4357 

## Additional info
The digger helmets don't have a common, unifying item tag, so I had to resort to making the title "Any Digger Helmet"