### PR TITLE
fix: bed can't set respawn point in beneath

### DIFF
--- a/kubejs/data/tfg/dimension_type/the_nether.json
+++ b/kubejs/data/tfg/dimension_type/the_nether.json
@@ -12,7 +12,7 @@
 	"min_y": 0,
 	"monster_spawn_block_light_limit": 15,
 	"monster_spawn_light_level": 7,
-	"natural": false,
+	"natural": true,
 	"piglin_safe": true,
 	"respawn_anchor_works": false,
 	"ultrawarm": false


### PR DESCRIPTION
Bed can't set respawn point in beneath bc of natural is false