### PR TITLE
fix firmalife dynamic food item size

### DIFF
--- a/kubejs/data/firmalife/tfc/item_sizes/dynamic_foods.json
+++ b/kubejs/data/firmalife/tfc/item_sizes/dynamic_foods.json
@@ -1,6 +1,6 @@
 {
   "ingredient": {
-    "item": "firmalife:foods/dynamic"
+    "tag": "firmalife:foods/dynamic"
   },
   "size": "very_small",
   "weight": "medium"


### PR DESCRIPTION
Fixes #4401.

### Summary

- change `firmalife:foods/dynamic` from an item ingredient to a tag ingredient
- preserve TFG's custom `weight: "medium"` override
