### PR TITLE
Add a few useful items to tool tack

### DIFF
--- a/kubejs/server_scripts/tfc/tags.js
+++ b/kubejs/server_scripts/tfc/tags.js
@@ -85,7 +85,11 @@ function registerTFCItemTags(event) {
 		"primitive_creatures:reh",
 		"species:harpoon",
 		"species:crankbow",
-		"tfg:trowel"
+		"tfg:trowel",
+		"tfc:ceramic/pot",
+		"minecraft:lead",
+		"gtceu:brick_wooden_form",
+		"firmalife:watering_can"
 	];
 	usableOnToolRack.forEach((entry) => {
 		event.add("tfc:usable_on_tool_rack", entry);


### PR DESCRIPTION
Adds the following items to tool racks:
- leads - to keep near where you keep your horse, or boat during winter because leads keep breaking
- pots - to keep near campfire/oven
- watering can - greenhouse 
- brick form - useful for crafting but needed very rarely so neat quick access yeah