### PR TITLE
Added *_greenhouse_roof to #firmalife:valid_always_greenshouse_wall

### DIFF
--- a/kubejs/server_scripts/firmalife/tags.js
+++ b/kubejs/server_scripts/firmalife/tags.js
@@ -46,6 +46,7 @@ const registerFirmaLifeBlockTags = (event) => {
 	greenhouse_tiers.forEach(tier => {
 		event.add('firmalife:always_valid_greenhouse_wall', `firmalife:${  tier  }_greenhouse_door`)
 		event.add('firmalife:always_valid_greenhouse_wall', `firmalife:${  tier  }_greenhouse_trapdoor`)
+		event.add('firmalife:always_valid_greenhouse_wall', `firmalife:${  tier  }_greenhouse_roof`)
 	})
 
     //Allows any block with the word "brick" in its id to be used as oven insulation.


### PR DESCRIPTION
## What is the new behavior?
Added the tag #firmalife:valid_always_greenshouse_wall to all of the greenhouse_roof blocks so they can be used as "solid" building blocks for building a greenhouse.
 
## Outcome
Fixes: #4250