### PR TITLE
(bug) Fixed a typo in the spelling of "creosote" for some translations.

### DIFF
--- a/kubejs/assets/tfg/lang/en_us.json
+++ b/kubejs/assets/tfg/lang/en_us.json
@@ -4814,7 +4814,7 @@
 	"quests.tfg_tips.creosote.title": "Lamp Fuel: Weak Fuels",
 	"quests.tfg_tips.creosote.subtitle": "If you have a bunch of it lying around...",
 	"quests.tfg_tips.creosote.desc": "&dCreosote&r and &dGregTech Oils&r can be used as a lamp fuel, but a full lamp of the stuff only lasts for &c10&r days.",
-	"quests.tfg_tips.creosote.task_croesote": "A Bucket of Creosote",
+	"quests.tfg_tips.creosote.task_creosote": "A Bucket of Creosote",
 	"quests.tfg_tips.creosote.task_oil": "A Bucket of Oil",
 	"quests.tfg_tips.creosote.task_light_oil": "A Bucket of Light Oil",
 	"quests.tfg_tips.creosote.task_raw_oil": "A Bucket of Raw Oil",

--- a/kubejs/assets/tfg/lang/ja_jp.json
+++ b/kubejs/assets/tfg/lang/ja_jp.json
@@ -6796,7 +6796,7 @@
 	"quests.tfg_tips.creosote.title": "ランタン燃料:弱めな燃料",
 	"quests.tfg_tips.creosote.subtitle": "余っていたら",
 	"quests.tfg_tips.creosote.desc": "&dクレオソート&rと &dGregTech系の油&rはランタン燃料として使用できますが、この燃料で満たされたランタンは&c10&r日間しか持続しません。",
-	"quests.tfg_tips.creosote.task_croesote": "クレオソート油バケツ",
+	"quests.tfg_tips.creosote.task_creosote": "クレオソート油バケツ",
 	"quests.tfg_tips.creosote.task_oil": "原油バケツ",
 	"quests.tfg_tips.creosote.task_light_oil": "軽油バケツ",
 	"quests.tfg_tips.creosote.task_raw_oil": "原料油バケツ",

--- a/kubejs/assets/tfg/lang/pl_pl.json
+++ b/kubejs/assets/tfg/lang/pl_pl.json
@@ -4848,7 +4848,7 @@
 	"quests.tfg_tips.lamps.title": "Lampy",
 	"quests.tfg_tips.lamps.subtitle": "Całkiem ładne.",
 	"quests.tfg_tips.creosote.title": "Paliwo do lampy: Słabe paliwa",
-	"quests.tfg_tips.creosote.task_croesote": "Wiadro kreozotu",
+	"quests.tfg_tips.creosote.task_creosote": "Wiadro kreozotu",
 	"quests.tfg_tips.creosote.task_oil": "Wiadro ropy naftowej",
 	"quests.tfg_tips.creosote.task_light_oil": "Wiadro lekkiego oleju",
 	"quests.tfg_tips.creosote.task_raw_oil": "Wiadro surowego oleju",

--- a/kubejs/assets/tfg/lang/ru_ru.json
+++ b/kubejs/assets/tfg/lang/ru_ru.json
@@ -7007,7 +7007,7 @@
 	"quests.tfg_tips.creosote.title": "Топливо для фонаря: Слабое топливо",
 	"quests.tfg_tips.creosote.subtitle": "Если у вас его много скопилось...",
 	"quests.tfg_tips.creosote.desc": "&dКреозот&r и %dGregTech масла%r можно использовать в качестве топлива для фонаря, но полностью заправленного фонаря хватит всего на &c10&r дней.",
-	"quests.tfg_tips.creosote.task_croesote": "Ведро креозота",
+	"quests.tfg_tips.creosote.task_creosote": "Ведро креозота",
 	"quests.tfg_tips.creosote.task_oil": "Ведро нефти",
 	"quests.tfg_tips.creosote.task_light_oil": "Ведро лёгкой нефти",
 	"quests.tfg_tips.creosote.task_raw_oil": "Ведро сырой нефти",

--- a/kubejs/assets/tfg/lang/uk_ua.json
+++ b/kubejs/assets/tfg/lang/uk_ua.json
@@ -6956,7 +6956,7 @@
 	"quests.tfg_tips.creosote.title": "Паливо для лампи: Слабкі палива",
 	"quests.tfg_tips.creosote.subtitle": "Якщо у тебе є багато цього під рукою...",
 	"quests.tfg_tips.creosote.desc": "&dКреозот&r та &dнафта GregTech&r можна використовувати як паливо для лампи, але повна лампа з цим паливом тримається лише &c10&r днів.",
-	"quests.tfg_tips.creosote.task_croesote": "Відро креозоту",
+	"quests.tfg_tips.creosote.task_creosote": "Відро креозоту",
 	"quests.tfg_tips.creosote.task_oil": "Відро нафти",
 	"quests.tfg_tips.creosote.task_light_oil": "Відро легкої нафти",
 	"quests.tfg_tips.creosote.task_raw_oil": "Відро сирої нафти",

--- a/kubejs/assets/tfg/lang/zh_cn.json
+++ b/kubejs/assets/tfg/lang/zh_cn.json
@@ -6957,7 +6957,7 @@
 	"quests.tfg_tips.creosote.title": "灯油：低效燃油",
 	"quests.tfg_tips.creosote.subtitle": "如果你有一堆闲置的话...",
 	"quests.tfg_tips.creosote.desc": "&d杂酚油&r和&d格雷科技的燃油&r都可以作为灯油，但满罐仅持续&c10&r天。",
-	"quests.tfg_tips.creosote.task_croesote": "一桶杂酚油",
+	"quests.tfg_tips.creosote.task_creosote": "一桶杂酚油",
 	"quests.tfg_tips.creosote.task_oil": "一桶石油",
 	"quests.tfg_tips.creosote.task_light_oil": "一桶轻油",
 	"quests.tfg_tips.creosote.task_raw_oil": "一桶原油",


### PR DESCRIPTION
## What is the new behavior?

Fixed a typo in the spelling of "creosote" for some translation files.

It was causing the translation for "A Bucket of Creosote Oil" to not show up in the game properly in the quest "Lamp Fuel: Weak Fuels".

## Outcome

The translation now shows correctly.

## Additional Information

**Behaviour Before Change**

<img width="832" height="475" alt="image" src="https://github.com/user-attachments/assets/48a9197a-e564-43da-b51d-fed2e48b92e8" />

**Behaviour After Change**

<img width="658" height="456" alt="image" src="https://github.com/user-attachments/assets/625870c7-175b-4f35-8ced-cfc3202461fe" />

No need to give me any Discord roles for such a basic change.