### PR TITLE
Add honeyed apples to constants.food.js to use in crafting

### DIFF
--- a/kubejs/startup_scripts/tfg/food/constants.food.js
+++ b/kubejs/startup_scripts/tfg/food/constants.food.js
@@ -698,6 +698,7 @@ global.FOOD_FRUIT = [
 	{name: 'peach', id: 'tfc:food/peach', color: 0xc56954, saturation: 0.4, water: 10, fruit: 0.5, decay: 2.5},
 	{name: 'plum', id: 'tfc:food/plum', color: 0x8a40b7, saturation: 0.4, water: 5, fruit: 0.8, decay: 2.25},
 	{name: 'red_apple', id: 'tfc:food/red_apple', color: 0x9f3131, saturation: 0.4, water: 0, fruit: 1, decay: 2.25},
+	{name: 'honeyed_apple', id: 'create:honeyed_apple', color: 0x9f3131, saturation: 0.4, water:0, fruit:1, sugary:1, decay: 2.25},
 	{name: 'pumpkin_chunks', id: 'tfc:food/pumpkin_chunks', color: 0xa97c4c, saturation: 1, water: 5, fruit: 0.8, decay: 2.25},
 	{name: 'melon_slice', id: 'tfc:food/melon_slice', color: 0xad160b, saturation: 0.2, water: 5, fruit: 0.8, decay: 2.25},
 	{name: 'fig', id: 'firmalife:food/fig', color: 0x9e4264, saturation: 1, water: 5, fruit: 0.9, decay: 1},


### PR DESCRIPTION
## What is the new behavior?
Honeyed apples can now be used for fruit crafting and cryodessication. In doing so, they lose their preservation bonus over regular apples, but still give the food the sugary trait.

## Implementation Details
Since honeyed apples aren't overpowered superfoods anymore (sorry about that), this shouldn't be too unbalanced. I intended honey to be a means of low-tech fruit preservation first.
The sugary value may be a little high. I quite like the effect of the weakness tradeoff for speed, though. Let me know if it's too much.
The color is the exact same as red apples. 

## Additional Information
<img width="1066" height="475" alt="image" src="https://github.com/user-attachments/assets/f3536484-efe3-48f3-8d10-484478da6a55" />
<img width="971" height="584" alt="image" src="https://github.com/user-attachments/assets/2758338c-5279-423c-a07a-285d82290144" />
<img width="1003" height="489" alt="image" src="https://github.com/user-attachments/assets/94ca43d4-50ef-48c6-ab3b-6693ddc76dd1" />


**Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role**
Froffy