### PR TITLE
Feature: added electrolyzer recipes for quartz and smoky quartz dusts

### DIFF
--- a/kubejs/server_scripts/tfg/ores_and_materials/recipes.quartzes.js
+++ b/kubejs/server_scripts/tfg/ores_and_materials/recipes.quartzes.js
@@ -22,7 +22,21 @@ function registerTFGQuartzRecipes(event) {
 		.itemOutputs('1x #forge:dusts/nether_quartz', '8x minecraft:redstone')
 		.duration(7 * 20)
 		.EUt(60)
-	//#endregion
+
+	event.recipes.gtceu.electrolyzer('electrolyze_smoky_quartz_dust')
+		.itemInputs('3x #forge:dusts/nether_quartz')
+		.itemOutputs('gtceu:silicon_dust')
+		.outputFluids(Fluid.of('gtceu:oxygen', 2000))
+		.duration(7 * 20)
+		.EUt(60)
+
+	event.recipes.gtceu.electrolyzer('electrolyze_quartz_dust')
+		.itemInputs('3x #forge:dusts/quartzite')
+		.itemOutputs('gtceu:silicon_dust')
+		.outputFluids(Fluid.of('gtceu:oxygen', 2000))
+		.duration(7 * 20)
+		.EUt(60)
+  //#endregion
 
 	//#region Glass
 

--- a/kubejs/server_scripts/tfg/ores_and_materials/recipes.quartzes.js
+++ b/kubejs/server_scripts/tfg/ores_and_materials/recipes.quartzes.js
@@ -23,14 +23,14 @@ function registerTFGQuartzRecipes(event) {
 		.duration(7 * 20)
 		.EUt(60)
 
-	event.recipes.gtceu.electrolyzer('electrolyze_smoky_quartz_dust')
+	event.recipes.gtceu.electrolyzer('tfg:electrolyze_smoky_quartz_dust')
 		.itemInputs('3x #forge:dusts/nether_quartz')
 		.itemOutputs('gtceu:silicon_dust')
 		.outputFluids(Fluid.of('gtceu:oxygen', 2000))
 		.duration(7 * 20)
 		.EUt(60)
 
-	event.recipes.gtceu.electrolyzer('electrolyze_quartz_dust')
+	event.recipes.gtceu.electrolyzer('tfg:electrolyze_quartz_dust')
 		.itemInputs('3x #forge:dusts/quartzite')
 		.itemOutputs('gtceu:silicon_dust')
 		.outputFluids(Fluid.of('gtceu:oxygen', 2000))


### PR DESCRIPTION
## What is the new behavior?
Added a recipe to electrolyze 3x quartz dust/smoky quartz dust into 1x silicon dust and 2B oxygen gas

## Implementation Details
Following the example set by rose quartz, I made both recipes 60 EU/t, 7 seconds. Could be altered if needed

## Outcome
Fixes #4539

## Additional Information
<img width="1920" height="1080" alt="2026-07-23_23 14 36" src="https://github.com/user-attachments/assets/dece6633-123b-4675-9d98-a7bea6cca81c" />
<img width="1920" height="1080" alt="2026-07-23_23 14 47" src="https://github.com/user-attachments/assets/254d1aca-9583-4b99-b8e6-61e341540921" />
