### PR TITLE
chore: normalize line-ending attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,8 @@
-# Set the default behavior:
-# On checkout, the line endings will be normalized to the correct one for the OS
-# On commit, the line endings will be reset to lf
-* text=auto
+# Normalize text to LF unless a path explicitly requires CRLF.
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.cmd text eol=crlf
 
 # Binary Files
 *.png binary


### PR DESCRIPTION
## What changed

- Normalize repository line-ending attributes.
- Keep text files on consistent LF/CRLF policies across Windows and Linux checkouts.

## Why

The repository did not consistently encode its intended line-ending behavior, which can create noisy or accidental whole-file changes.

## Validation

- Rebased onto the current upstream `dev` branch.
- `git diff --check` passes.
- The working tree is clean.
