### PR TITLE
Additions of New Jellies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ config/stellarcore_stitcher_cache_jei.dat
 config/stellarcore_stitcher_cache_vanilla.dat
 
 !config/defaultoptions/options.txt
-!config/jellies.yaml
 
 defaultconfigs/ftbranks/players.snbt
 

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ config/stellarcore_stitcher_cache_jei.dat
 config/stellarcore_stitcher_cache_vanilla.dat
 
 !config/defaultoptions/options.txt
+!config/jellies.yaml
 
 defaultconfigs/ftbranks/players.snbt
 

--- a/config/jellies.yaml
+++ b/config/jellies.yaml
@@ -19,7 +19,7 @@ entities:
 
     # How long it takes for a jellie to produce products.
     # Default: 23500
-    produceTicks: 23501
+    produceTicks: 23500
 
     # Minimum familiarity needed for jellie to produce products.
     # Default: 0.15

--- a/config/jellies.yaml
+++ b/config/jellies.yaml
@@ -1,0 +1,464 @@
+# Config options for jellie stats.
+entities:
+  biotiteJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23501
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+
+  certusJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+
+  glowberryJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+
+  herbalJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+
+  iceJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+
+  latexJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+
+  lavaJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+
+  penteticJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+
+  phosphorumJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+
+  plantJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+
+  rockJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+
+  springJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+
+  pyritieJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+
+  redeixJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 1
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 32
+

--- a/kubejs/data/tfg/worldgen/biome/mars/martian_deep_desert.json
+++ b/kubejs/data/tfg/worldgen/biome/mars/martian_deep_desert.json
@@ -75,7 +75,15 @@
 		}
 	},
 	"spawners": {
-		"ambient": [],
+		
+		"ambient": [
+			{
+				"type": "jellies:pentetic",
+				"maxCount": 2,
+				"minCount": 1,
+				"weight": 100
+			}
+		],
 		"axolotls": [],
 		"creature": [
 			{

--- a/kubejs/data/tfg/worldgen/biome/mars/martian_mountains.json
+++ b/kubejs/data/tfg/worldgen/biome/mars/martian_mountains.json
@@ -110,7 +110,14 @@
 		}
 	},
 	"spawners": {
-		"ambient": [],
+		"ambient": [
+			{
+				"type": "jellies:pentetic",
+				"maxCount": 2,
+				"minCount": 1,
+				"weight": 100
+			}
+		],
 		"axolotls": [],
 		"creature": [
 			{

--- a/kubejs/data/tfg/worldgen/biome/moon/lunar_asurine_dense.json
+++ b/kubejs/data/tfg/worldgen/biome/moon/lunar_asurine_dense.json
@@ -72,7 +72,14 @@
 		}
 	},
 	"spawners": {
-		"ambient": [],
+		"ambient": [
+			{
+				"type": "jellies:certus",
+				"maxCount": 4,
+				"minCount": 3,
+				"weight": 100
+			}
+		],
 		"axolotls": [],
 		"creature": [
 			{

--- a/kubejs/data/tfg/worldgen/biome/moon/lunar_asurine_sparse.json
+++ b/kubejs/data/tfg/worldgen/biome/moon/lunar_asurine_sparse.json
@@ -76,7 +76,14 @@
 		}
 	},
 	"spawners": {
-		"ambient": [],
+		"ambient": [
+			{
+				"type": "jellies:certus",
+				"maxCount": 2,
+				"minCount": 1,
+				"weight": 100
+			}
+		],
 		"axolotls": [],
 		"creature": [
 			{

--- a/kubejs/data/tfg/worldgen/biome/nether/ash_forest.json
+++ b/kubejs/data/tfg/worldgen/biome/nether/ash_forest.json
@@ -81,7 +81,7 @@
 	"spawners": {
 		"ambient": [
 			{
-				"type": "jellies:lava",
+				"type": "jellies:biotite",
 				"maxCount": 4,
 				"minCount": 3,
 				"weight": 100

--- a/kubejs/server_scripts/jellies/recipes.js
+++ b/kubejs/server_scripts/jellies/recipes.js
@@ -76,15 +76,15 @@ function registerJelliesRecipes(event) {
 		.EUt(GTValues.VA[GTValues.ULV])
 	
 	// Plant Slime Ball
-	event.shapeless('gtceu:plant_ball', ['jellies:jellie/slime_ball/plant', '#forge:tools/mortars'])
+	event.shapeless('2x gtceu:plant_ball', ['jellies:jellie/slime_ball/plant', '#forge:tools/mortars'])
 		.id('tfg:shapeless/mortar_plant_slime_ball')
 
-	event.recipes.tfc.quern('gtceu:plant_ball', 'jellies:jellie/slime_ball/plant')
+	event.recipes.tfc.quern('2x gtceu:plant_ball', 'jellies:jellie/slime_ball/plant')
 		.id('tfg:quern/plant_slime_ball')
 
 	event.recipes.gtceu.macerator('tfg:plant_slime_ball')
 		.itemInputs('jellies:jellie/slime_ball/plant')
-		.itemOutputs('gtceu:plant_ball')
+		.itemOutputs('2x gtceu:plant_ball')
 		.duration(50)
 		.EUt(GTValues.VA[GTValues.ULV])
 

--- a/kubejs/server_scripts/jellies/recipes.js
+++ b/kubejs/server_scripts/jellies/recipes.js
@@ -2,6 +2,7 @@
 "use strict";
 
 function registerJelliesRecipes(event) {
+	// Jellie Slime Ball to Minecraft Slime Ball
 	event.custom({
 		type: "ae2:transform",
 		circumstance: {
@@ -19,20 +20,20 @@ function registerJelliesRecipes(event) {
 		.duration(50)
 		.EUt(GTValues.VA[GTValues.ULV])
 
-	// Plant slime ball
-	event.shapeless('gtceu:plant_ball', ['jellies:jellie/slime_ball/plant', '#forge:tools/mortars'])
-		.id('tfg:shapeless/mortar_plant_slime_ball')
+	// Biotite Slime Ball
+	event.shapeless('gtceu:biotite_dust', ['jellies:jellie/slime_ball/biotite', '#forge:tools/mortars'])
+		.id('tfg:shapeless/mortar_biotite_slime_ball')
 
-	event.recipes.tfc.quern('gtceu:plant_ball', 'jellies:jellie/slime_ball/plant')
-		.id('tfg:quern/plant_slime_ball')
+	event.recipes.tfc.quern('gtceu:biotite_dust', 'jellies:jellie/slime_ball/biotite')
+		.id('tfg:quern/biotite_slime_ball')
 
-	event.recipes.gtceu.macerator('tfg:plant_slime_ball')
-		.itemInputs('jellies:jellie/slime_ball/plant')
-		.itemOutputs('gtceu:plant_ball')
-		.EUt(2)
+	event.recipes.gtceu.macerator('tfg:biotite_slime_ball')
+		.itemInputs('jellies:jellie/slime_ball/biotite')
+		.itemOutputs('gtceu:biotite_dust')
 		.duration(50)
+		.EUt(GTValues.VA[GTValues.ULV])
 
-	// Glowberry slime ball
+	// Glowberry Slime Ball
 	for (let i = 1; i <= 5; i++) {
 		let inputArray = new Array(0)
 		let outputArray = new Array(0)
@@ -53,14 +54,14 @@ function registerJelliesRecipes(event) {
 		.length(600)
 		.id('tfg:vat/glowberry_slime_ball_to_sugar')
 
-	event.recipes.gtceu.brewery('tfg:glowberry_slime_ball')
+	event.recipes.gtceu.chemical_reactor('tfg:glowberry_slime_ball')
 		.itemInputs('jellies:jellie/slime_ball/glowberry')
 		.inputFluids(Fluid.of('tfc:spring_water', 200))
 		.itemOutputs('minecraft:sugar')
 		.duration(100)
-		.EUt(16)
+		.EUt(GTValues.VA[GTValues.ULV])
 
-	// Latex slime ball
+	// Latex Slime Ball
 	event.recipes.firmalife.vat()
 		.inputs('jellies:jellie/slime_ball/latex', Fluid.of('tfc:spring_water', 200))
 		.outputFluid(Fluid.of('tfg:latex', 200))
@@ -72,5 +73,31 @@ function registerJelliesRecipes(event) {
 		.inputFluids(Fluid.of('tfc:spring_water', 200))
 		.outputFluids(Fluid.of('tfg:latex', 200))
 		.duration(100)
-		.EUt(16)
+		.EUt(GTValues.VA[GTValues.ULV])
+	
+	// Plant Slime Ball
+	event.shapeless('gtceu:plant_ball', ['jellies:jellie/slime_ball/plant', '#forge:tools/mortars'])
+		.id('tfg:shapeless/mortar_plant_slime_ball')
+
+	event.recipes.tfc.quern('gtceu:plant_ball', 'jellies:jellie/slime_ball/plant')
+		.id('tfg:quern/plant_slime_ball')
+
+	event.recipes.gtceu.macerator('tfg:plant_slime_ball')
+		.itemInputs('jellies:jellie/slime_ball/plant')
+		.itemOutputs('gtceu:plant_ball')
+		.duration(50)
+		.EUt(GTValues.VA[GTValues.ULV])
+
+	// Spring Slime Ball
+	event.recipes.firmalife.vat()
+		.inputItem('jellies:jellie/slime_ball/spring')
+		.outputFluid(Fluid.of('tfc:spring_water', 200))
+		.length(600)
+		.id('tfg:vat/spring_slime_ball_to_spring_water')
+
+	event.recipes.gtceu.brewery('tfg:spring_slime_ball')
+		.itemInputs('jellies:jellie/slime_ball/spring')
+		.outputFluids(Fluid.of('tfc:spring_water', 200))
+		.duration(100)
+		.EUt(GTValues.VA[GTValues.ULV])
 }

--- a/kubejs/server_scripts/jellies/tags.js
+++ b/kubejs/server_scripts/jellies/tags.js
@@ -3,4 +3,6 @@
 
 function registerJelliesItemTags(event) {
 	event.add("jellies:jellie_food", "#beneath:mushrooms");
+	event.add("jellies:jellie/slime_ball/plant", "#tfc:compost_greens")
+	event.add("jellies:jellie/slime_ball/phosphorum", "#tfc:compost_browns")
 }

--- a/kubejs/server_scripts/jellies/tags.js
+++ b/kubejs/server_scripts/jellies/tags.js
@@ -1,8 +1,38 @@
 // priority: 0
 "use strict";
 
+// I will add a general tag to all jellies in next update
+const allJellies = [
+	'biotite',
+	'certus',
+	'glowberry',
+	'herbal',
+	'ice',
+	'latex',
+	'lava',
+	'pentetic',
+	'phosphorum',
+	'plant',
+	'rock',
+	'spring',
+	'pyritie',
+	'eevee'
+]
+
 function registerJelliesItemTags(event) {
-	event.add("jellies:jellie_food", "#beneath:mushrooms");
+	event.add("jellies:jellie_food", "#forge:mushrooms");
 	event.add("jellies:jellie/slime_ball/plant", "#tfc:compost_greens")
 	event.add("jellies:jellie/slime_ball/phosphorum", "#tfc:compost_browns")
+}
+
+function registerJelliesEntityTags(event) {
+	event.add('tfc:vanilla_monsters', 'jellies:rock')
+
+	allJellies.forEach(jellie => {
+		event.add('ad_astra:lives_without_oxygen', `jellies:${jellie}`)
+		event.add('ad_astra:can_survive_extreme_cold', `jellies:${jellie}`)
+		event.add('ad_astra:can_survive_extreme_heat', `jellies:${jellie}`)
+		event.add('ad_astra:can_survive_in_space', `jellies:${jellie}`)
+		event.add('ad_astra:can_survive_in_acid_rain', `jellies:${jellie}`)
+	})
 }

--- a/kubejs/server_scripts/jellies/tags.js
+++ b/kubejs/server_scripts/jellies/tags.js
@@ -10,11 +10,9 @@ function registerJelliesItemTags(event) {
 function registerJelliesEntityTags(event) {
 	event.add('tfc:vanilla_monsters', 'jellies:rock')
 
-	allJellies.forEach(jellie => {
-		event.add('ad_astra:lives_without_oxygen', '#jellies:jellie')
-		event.add('ad_astra:can_survive_extreme_cold', '#jellies:jellie')
-		event.add('ad_astra:can_survive_extreme_heat', '#jellies:jellie')
-		event.add('ad_astra:can_survive_in_space', '#jellies:jellie')
-		event.add('ad_astra:can_survive_in_acid_rain', '#jellies:jellie')
-	})
+	event.add('ad_astra:lives_without_oxygen', '#jellies:jellie')
+	event.add('ad_astra:can_survive_extreme_cold', '#jellies:jellie')
+	event.add('ad_astra:can_survive_extreme_heat', '#jellies:jellie')
+	event.add('ad_astra:can_survive_in_space', '#jellies:jellie')
+	event.add('ad_astra:can_survive_in_acid_rain', '#jellies:jellie')
 }

--- a/kubejs/server_scripts/jellies/tags.js
+++ b/kubejs/server_scripts/jellies/tags.js
@@ -1,24 +1,6 @@
 // priority: 0
 "use strict";
 
-// I will add a general tag to all jellies in next update
-const allJellies = [
-	'biotite',
-	'certus',
-	'glowberry',
-	'herbal',
-	'ice',
-	'latex',
-	'lava',
-	'pentetic',
-	'phosphorum',
-	'plant',
-	'rock',
-	'spring',
-	'pyritie',
-	'eevee'
-]
-
 function registerJelliesItemTags(event) {
 	event.add("jellies:jellie_food", "#forge:mushrooms");
 	event.add("jellies:jellie/slime_ball/plant", "#tfc:compost_greens")
@@ -29,10 +11,10 @@ function registerJelliesEntityTags(event) {
 	event.add('tfc:vanilla_monsters', 'jellies:rock')
 
 	allJellies.forEach(jellie => {
-		event.add('ad_astra:lives_without_oxygen', `jellies:${jellie}`)
-		event.add('ad_astra:can_survive_extreme_cold', `jellies:${jellie}`)
-		event.add('ad_astra:can_survive_extreme_heat', `jellies:${jellie}`)
-		event.add('ad_astra:can_survive_in_space', `jellies:${jellie}`)
-		event.add('ad_astra:can_survive_in_acid_rain', `jellies:${jellie}`)
+		event.add('ad_astra:lives_without_oxygen', '#jellies:jellie')
+		event.add('ad_astra:can_survive_extreme_cold', '#jellies:jellie')
+		event.add('ad_astra:can_survive_extreme_heat', '#jellies:jellie')
+		event.add('ad_astra:can_survive_in_space', '#jellies:jellie')
+		event.add('ad_astra:can_survive_in_acid_rain', '#jellies:jellie')
 	})
 }

--- a/kubejs/server_scripts/jellies/tags.js
+++ b/kubejs/server_scripts/jellies/tags.js
@@ -3,8 +3,8 @@
 
 function registerJelliesItemTags(event) {
 	event.add("jellies:jellie_food", "#forge:mushrooms");
-	event.add("jellies:jellie/slime_ball/plant", "#tfc:compost_greens")
-	event.add("jellies:jellie/slime_ball/phosphorum", "#tfc:compost_browns")
+	event.add("jellies:jellie/slime_ball/plant", "#tfc:compost_greens_high")
+	event.add("jellies:jellie/slime_ball/phosphorum", "#tfc:compost_browns_high")
 }
 
 function registerJelliesEntityTags(event) {

--- a/kubejs/server_scripts/main_server_script.js
+++ b/kubejs/server_scripts/main_server_script.js
@@ -129,6 +129,7 @@ ServerEvents.tags('worldgen/biome', event => {
 })
 
 ServerEvents.tags('entity_type', event => {
+	registerJelliesEntityTags(event)
 	registerTFGEntityTypeTags(event)
 	registerWABEntityTypeTags(event)
 })

--- a/kubejs/server_scripts/tfg/primitive/medicine/recipes.medicine.js
+++ b/kubejs/server_scripts/tfg/primitive/medicine/recipes.medicine.js
@@ -5,573 +5,115 @@
  * @param {Internal.RecipesEventJS} event 
  */
 function registerTFGMedicineRecipes(event) {
-
-	//#region Antipoison
-
-	event.recipes.firmalife.mixing_bowl()
-		.ingredients(['#forge:wax', '#tfg:antipoison_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1)], Fluid.of('tfc:spring_water', 250))
-		.outputItem('1x tfg:antipoison_pill')
-		.id(`tfg:mixing_bowl/pill_antipoison`)
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/pill_antipoison`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:antipoison_pill')
-		.itemInputs('#forge:wax', '#tfg:antipoison_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/pill_antipoison`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:antipoison_pill')
-		.itemInputs('#forge:wax', '#tfg:antipoison_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/tablet_antipoison`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:antipoison_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:antipoison_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/tablet_antipoison`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:antipoison_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:antipoison_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	//#endregion
-
-	//#region Poison
-	
-	event.recipes.firmalife.mixing_bowl()
-		.ingredients(['#forge:wax', '#tfg:poison_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1)], Fluid.of('tfc:spring_water', 250))
-		.outputItem('1x tfg:poison_pill')
-		.id(`tfg:mixing_bowl/pill_poison`)
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/pill_poison`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:poison_pill')
-		.itemInputs('#forge:wax', '#tfg:poison_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/pill_poison`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:poison_pill')
-		.itemInputs('#forge:wax', '#tfg:poison_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/tablet_poison`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:poison_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:poison_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/tablet_poison`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:poison_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:poison_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	// Arrow
-	event.shapeless(Item.of('8x minecraft:tipped_arrow', '{Potion:"minecraft:poison"}'),
-		['4x minecraft:arrow', 'tfg:poison_pill', '4x minecraft:arrow'])
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/poison_1`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:poison"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:poison_pill')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/poison_2`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:long_poison"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:poison_tablet')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-
-	//#endregion
-
-	//#region Regeneration
-	
-	event.recipes.firmalife.mixing_bowl()
-		.ingredients(['#forge:wax', '#tfg:regeneration_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1)], Fluid.of('tfc:spring_water', 250))
-		.outputItem('1x tfg:regeneration_pill')
-		.id(`tfg:mixing_bowl/pill_regeneration`)
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/pill_regeneration`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:regeneration_pill')
-		.itemInputs('#forge:wax', '#tfg:regeneration_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/pill_regeneration`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:regeneration_pill')
-		.itemInputs('#forge:wax', '#tfg:regeneration_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/tablet_regeneration`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:regeneration_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:regeneration_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/tablet_regeneration`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:regeneration_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:regeneration_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	// Arrow
-	event.shapeless(Item.of('8x minecraft:tipped_arrow', '{Potion:"minecraft:regeneration"}'),
-		['4x minecraft:arrow', 'tfg:regeneration_pill', '4x minecraft:arrow'])
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/regeneration_1`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:regeneration"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:regeneration_pill')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/regeneration_2`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:long_regeneration"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:regeneration_tablet')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-
-	//#endregion
-
-	//#region Speed
-	
-	event.recipes.firmalife.mixing_bowl()
-		.ingredients(['#forge:wax', '#tfg:speed_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1)], Fluid.of('tfc:spring_water', 250))
-		.outputItem('1x tfg:speed_pill')
-		.id(`tfg:mixing_bowl/pill_speed`)
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/pill_speed`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:speed_pill')
-		.itemInputs('#forge:wax', '#tfg:speed_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/pill_speed`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:speed_pill')
-		.itemInputs('#forge:wax', '#tfg:speed_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/tablet_speed`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:speed_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:speed_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/tablet_speed`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:speed_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:speed_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	// Arrow
-	event.shapeless(Item.of('8x minecraft:tipped_arrow', '{Potion:"minecraft:swiftness"}'),
-		['4x minecraft:arrow', 'tfg:speed_pill', '4x minecraft:arrow'])
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/swiftness_1`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:swiftness"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:speed_pill')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/swiftness_2`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:long_swiftness"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:speed_tablet')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-
-	//#endregion
-
-	//#region Slowness
-	
-	event.recipes.firmalife.mixing_bowl()
-		.ingredients(['#forge:wax', '#tfg:slowness_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1)], Fluid.of('tfc:spring_water', 250))
-		.outputItem('1x tfg:slowness_pill')
-		.id(`tfg:mixing_bowl/pill_slowness`)
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/pill_slowness`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:slowness_pill')
-		.itemInputs('#forge:wax', '#tfg:slowness_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/pill_slowness`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:slowness_pill')
-		.itemInputs('#forge:wax', '#tfg:slowness_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/tablet_slowness`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:slowness_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:slowness_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/tablet_slowness`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:slowness_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:slowness_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	// Arrow
-	event.shapeless(Item.of('8x minecraft:tipped_arrow', '{Potion:"minecraft:slowness"}'),
-		['4x minecraft:arrow', 'tfg:slowness_pill', '4x minecraft:arrow'])
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/slowness_1`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:slowness"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:slowness_pill')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/slowness_2`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:long_slowness"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:slowness_tablet')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-
-	//#endregion
-
-	//#region Weakness
-
-	event.recipes.firmalife.mixing_bowl()
-		.ingredients(['#forge:wax', '#tfg:weakness_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1)], Fluid.of('tfc:spring_water', 250))
-		.outputItem('1x tfg:weakness_pill')
-		.id(`tfg:mixing_bowl/pill_weakness`)
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/pill_weakness`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:weakness_pill')
-		.itemInputs('#forge:wax', '#tfg:weakness_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/pill_weakness`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:weakness_pill')
-		.itemInputs('#forge:wax', '#tfg:weakness_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/tablet_weakness`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:weakness_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:weakness_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/tablet_weakness`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:weakness_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:weakness_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sulfur, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	// Arrow
-	event.shapeless(Item.of('8x minecraft:tipped_arrow', '{Potion:"minecraft:weakness"}'),
-		['4x minecraft:arrow', 'tfg:weakness_pill', '4x minecraft:arrow'])
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/weakness_1`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:weakness"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:weakness_pill')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/weakness_2`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:long_weakness"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:weakness_tablet')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-
-	//#endregion
-
-	//#region Haste
-
-	event.recipes.firmalife.mixing_bowl()
-		.ingredients(['#forge:wax', '#tfg:haste_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1)], Fluid.of('tfc:spring_water', 250))
-		.outputItem('1x tfg:haste_pill')
-		.id(`tfg:mixing_bowl/pill_haste`)
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/pill_haste`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:haste_pill')
-		.itemInputs('#forge:wax', '#tfg:haste_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/pill_haste`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:haste_pill')
-		.itemInputs('#forge:wax', '#tfg:haste_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/tablet_haste`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:haste_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:haste_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/tablet_haste`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:haste_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:haste_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	//#endregion
-
-	//#region Water Breathing
-
-	event.recipes.firmalife.mixing_bowl()
-		.ingredients(['#forge:wax', '#tfg:water_breathing_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1)], Fluid.of('tfc:spring_water', 250))
-		.outputItem('1x tfg:water_breathing_pill')
-		.id(`tfg:mixing_bowl/pill_water_breathing`)
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/pill_water_breathing`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:water_breathing_pill')
-		.itemInputs('#forge:wax', '#tfg:water_breathing_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/pill_water_breathing`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:water_breathing_pill')
-		.itemInputs('#forge:wax', '#tfg:water_breathing_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/tablet_water_breathing`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:water_breathing_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:water_breathing_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/tablet_water_breathing`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:water_breathing_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:water_breathing_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	// Arrow
-	event.shapeless(Item.of('8x minecraft:tipped_arrow', '{Potion:"minecraft:water_breathing"}'),
-		['4x minecraft:arrow', 'tfg:water_breathing_pill', '4x minecraft:arrow'])
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/water_breathing_1`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:water_breathing"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:water_breathing_pill')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/water_breathing_2`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:long_water_breathing"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:water_breathing_tablet')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-
-	//#endregion
-
-	//#region Night Vision
-
-	event.recipes.firmalife.mixing_bowl()
-		.ingredients(['#forge:wax', '#tfg:night_vision_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1)], Fluid.of('tfc:spring_water', 250))
-		.outputItem('1x tfg:night_vision_pill')
-		.id(`tfg:mixing_bowl/pill_night_vision`)
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/pill_night_vision`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:night_vision_pill')
-		.itemInputs('#forge:wax', '#tfg:night_vision_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/pill_night_vision`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:night_vision_pill')
-		.itemInputs('#forge:wax', '#tfg:night_vision_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/tablet_night_vision`)
-		.circuit(4)
-		.inputFluids(Fluid.of('tfc:spring_water', 250))
-		.itemOutputs('2x tfg:night_vision_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:night_vision_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/tablet_night_vision`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
-		.itemOutputs('2x tfg:night_vision_tablet')
-		.notConsumable('gtceu:pill_casting_mold')
-		.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', '#tfg:night_vision_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	// Arrow
-	event.shapeless(Item.of('8x minecraft:tipped_arrow', '{Potion:"minecraft:night_vision"}'),
-		['4x minecraft:arrow', 'tfg:night_vision_pill', '4x minecraft:arrow'])
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/night_vision_1`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:night_vision"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:night_vision_pill')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/night_vision_2`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:ethanol', 25))
-		.itemOutputs(Item.of('16x minecraft:tipped_arrow', '{Potion:"minecraft:long_night_vision"}'))
-		.itemInputs('16x minecraft:arrow', 'tfg:night_vision_tablet')
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.MV])
-
-	//#endregion
-
-	//#region Invisibility
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/salvo_invisibility`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:creosote', 500))
-		.itemOutputs('1x tfg:invisibility_salvo')
-		.itemInputs('gtceu:sticky_resin', '#tfg:invisibility_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	//#endregion
-
-	//#region Fire Resistance
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/salvo_fire_resistance`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:creosote', 500))
-		.itemOutputs('1x tfg:fire_resistance_salvo')
-		.itemInputs('gtceu:sticky_resin', '#tfg:fire_resistance_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	//#endregion
-
-	//#region Resistance
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/salvo_resistance`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:creosote', 500))
-		.itemOutputs('1x tfg:resistance_salvo')
-		.itemInputs('gtceu:sticky_resin', '#tfg:resistance_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	//#endregion
-
-	//#region Instant Health
-	
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/salvo_instant_health`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:creosote', 500))
-		.itemOutputs('1x tfg:instant_health_salvo')
-		.itemInputs('gtceu:sticky_resin', '#tfg:instant_health_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	//#endregion
-
-	//#region Absorption
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/salvo_absorption`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:creosote', 500))
-		.itemOutputs('1x tfg:absorption_salvo')
-		.itemInputs('gtceu:sticky_resin', '#tfg:absorption_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	//#endregion
-
-	//#region Luck
-
-	event.recipes.gtceu.mixer(`tfg:gtceu/mixer/salvo_luck`)
-		.circuit(4)
-		.inputFluids(Fluid.of('gtceu:creosote', 500))
-		.itemOutputs('1x tfg:luck_salvo')
-		.itemInputs('gtceu:sticky_resin', '#tfg:luck_ingredients', ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
-		.duration(200)
-		.EUt(GTValues.VA[GTValues.LV])
-
-	//#endregion
-
-	//#region mixing bowl recipes for salvos
+	//#region Pills & Tables
+
+	const pillTypes = [
+		{ name: 'antipoison', extra: GTMaterials.TricalciumPhosphate, makeArrow: false },
+		{ name: 'water_breathing', extra: GTMaterials.TricalciumPhosphate, makeArrow: true },
+		{ name: 'poison', extra: GTMaterials.Sulfur, makeArrow: true },
+		{ name: 'slowness', extra: GTMaterials.Sulfur, makeArrow: true },
+		{ name: 'weakness', extra: GTMaterials.Sulfur, makeArrow: true },
+		{ name: 'haste', extra: GTMaterials.TricalciumPhosphate, makeArrow: false },
+		{ name: 'night_vision', extra: GTMaterials.TricalciumPhosphate, makeArrow: true },
+		{ name: 'regeneration', extra: GTMaterials.TricalciumPhosphate, makeArrow: true },
+		{ name: 'speed', extra: GTMaterials.TricalciumPhosphate, makeArrow: true }
+	]
+
+	pillTypes.forEach(type => {
+		// Regular
+		event.recipes.firmalife.mixing_bowl()
+			.ingredients(['#forge:wax', `#tfg:${type.name}_ingredients`, ChemicalHelper.get(TagPrefix.dust, type.extra, 1)], Fluid.of('tfc:spring_water', 250))
+			.outputItem(`1x tfg:${type.name}_pill`)
+			.id(`tfg:mixing_bowl/pill_${type.name}`)
+
+		event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/pill_${type.name}`)
+			.circuit(4)
+			.inputFluids(Fluid.of('tfc:spring_water', 250))
+			.itemOutputs(`2x tfg:${type.name}_pill`)
+			.itemInputs('#forge:wax', `#tfg:${type.name}_ingredients`, ChemicalHelper.get(TagPrefix.dust, type.extra, 1))
+			.duration(200)
+			.EUt(GTValues.VA[GTValues.LV])
+		event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/pill_${type.name}`)
+			.circuit(4)
+			.inputFluids(Fluid.of('gtceu:distilled_water', 50))
+			.itemOutputs(`2x tfg:${type.name}_pill`)
+			.itemInputs('#forge:wax', `#tfg:${type.name}_ingredients`, ChemicalHelper.get(TagPrefix.dust, type.extra, 1))
+			.duration(200)
+			.EUt(GTValues.VA[GTValues.LV])
+		event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/tablet_${type.name}`)
+			.circuit(4)
+			.inputFluids(Fluid.of('tfc:spring_water', 250))
+			.itemOutputs(`2x tfg:${type.name}_tablet`)
+			.notConsumable('gtceu:pill_casting_mold')
+			.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', `#tfg:${type.name}_ingredients`, ChemicalHelper.get(TagPrefix.dust, type.extra, 1))
+			.duration(200)
+			.EUt(GTValues.VA[GTValues.LV])
+		event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/tablet_${type.name}`)
+			.circuit(4)
+			.inputFluids(Fluid.of('gtceu:distilled_water', 50))
+			.itemOutputs(`2x tfg:${type.name}_tablet`)
+			.notConsumable('gtceu:pill_casting_mold')
+			.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', `#tfg:${type.name}_ingredients`, ChemicalHelper.get(TagPrefix.dust, type.extra, 1))
+			.duration(200)
+			.EUt(GTValues.VA[GTValues.LV])
+
+		// With Herbal Slime Ball
+		event.recipes.firmalife.mixing_bowl()
+			.itemIngredients(['#forge:wax', `#tfg:${type.name}_ingredients`, 'jellies:jellie/slime_ball/herbal'])
+			.outputItem(`2x tfg:${type.name}_pill`)
+			.id(`tfg:mixing_bowl/pill_${type.name}_with_herbal_slime_ball`)
+
+		event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/pill_${type.name}_with_herbal_slime_ball`)
+			.circuit(4)
+			.itemOutputs(`4x tfg:${type.name}_pill`)
+			.itemInputs('#forge:wax', `#tfg:${type.name}_ingredients`, 'jellies:jellie/slime_ball/herbal')
+			.duration(200)
+			.EUt(GTValues.VA[GTValues.LV])
+		event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/pill_${type.name}_with_herbal_slime_ball`)
+			.circuit(4)
+			.itemOutputs(`4x tfg:${type.name}_pill`)
+			.itemInputs('#forge:wax', `#tfg:${type.name}_ingredients`, 'jellies:jellie/slime_ball/herbal')
+			.duration(200)
+			.EUt(GTValues.VA[GTValues.LV])
+		event.recipes.gtceu.mixer(`tfg:gtceu/mixer/spring_water/tablet_${type.name}_with_herbal_slime_ball`)
+			.circuit(4)
+			.itemOutputs(`4x tfg:${type.name}_tablet`)
+			.notConsumable('gtceu:pill_casting_mold')
+			.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', `#tfg:${type.name}_ingredients`, 'jellies:jellie/slime_ball/herbal')
+			.duration(200)
+			.EUt(GTValues.VA[GTValues.LV])
+		event.recipes.gtceu.mixer(`tfg:gtceu/mixer/distilled_water/tablet_${type.name}_with_herbal_slime_ball`)
+			.circuit(4)
+			.itemOutputs(`4x tfg:${type.name}_tablet`)
+			.notConsumable('gtceu:pill_casting_mold')
+			.itemInputs('gtceu:sodium_bicarbonate_dust', 'gtceu:lactose_dust', `#tfg:${type.name}_ingredients`, 'jellies:jellie/slime_ball/herbal')
+			.duration(200)
+			.EUt(GTValues.VA[GTValues.LV])
+
+		// Arrow
+		if(type.makeArrow) {
+			event.shapeless(Item.of('8x minecraft:tipped_arrow', `{Potion:"minecraft:${type.name}"}`),
+				['4x minecraft:arrow', `tfg:${type.name}_pill`, '4x minecraft:arrow'])
+
+			event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/${type.name}_1`)
+				.circuit(4)
+				.inputFluids(Fluid.of('gtceu:ethanol', 25))
+				.itemOutputs(Item.of('16x minecraft:tipped_arrow', `{Potion:"minecraft:${type.name}"}`))
+				.itemInputs('16x minecraft:arrow', `tfg:${type.name}_pill`)
+				.duration(200)
+				.EUt(GTValues.VA[GTValues.MV])
+
+			event.recipes.gtceu.mixer(`tfg:gtceu/mixer/arrow/${type.name}_2`)
+				.circuit(4)
+				.inputFluids(Fluid.of('gtceu:ethanol', 25))
+				.itemOutputs(Item.of('16x minecraft:tipped_arrow', `{Potion:"minecraft:long_${type.name}"}`))
+				.itemInputs('16x minecraft:arrow', `tfg:${type.name}_tablet`)
+				.duration(200)
+				.EUt(GTValues.VA[GTValues.MV])
+		}
+	})
+
+	//#region Salvos
 
 	const salvoTypes = [
 		'luck',
@@ -583,15 +125,37 @@ function registerTFGMedicineRecipes(event) {
 	]
 
 	salvoTypes.forEach(type => {
+		// Regular
 		event.recipes.firmalife.mixing_bowl()
-		.ingredients(['gtceu:sticky_resin', `#tfg:${type}_ingredients`, ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1)], Fluid.of('gtceu:creosote', 500))
-		.outputItem(`1x tfg:${type}_salvo`)
-		.id(`tfg:mixing_bowl/${type}_salvo`)
+			.ingredients(['gtceu:sticky_resin', `#tfg:${type}_ingredients`, ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1)], Fluid.of('gtceu:creosote', 500))
+			.outputItem(`1x tfg:${type}_salvo`)
+			.id(`tfg:mixing_bowl/${type}_salvo`)
+
+		event.recipes.gtceu.mixer(`tfg:gtceu/mixer/${type}_salvo`)
+			.circuit(4)
+			.inputFluids(Fluid.of('gtceu:creosote', 500))
+			.itemOutputs(`1x tfg:${type}_salvo`)
+			.itemInputs('gtceu:sticky_resin', `#tfg:${type}_ingredients`, ChemicalHelper.get(TagPrefix.dust, GTMaterials.TricalciumPhosphate, 1))
+			.duration(200)
+			.EUt(GTValues.VA[GTValues.LV])
+
+		// With Herbal Slime Ball
+		event.recipes.firmalife.mixing_bowl()
+			.itemIngredients(['gtceu:sticky_resin', `#tfg:${type}_ingredients`, 'jellies:jellie/slime_ball/herbal'])
+			.outputItem(`2x tfg:${type}_salvo`)
+			.id(`tfg:mixing_bowl/${type}_salvo_with_herbal_slime_ball`)
+
+		event.recipes.gtceu.mixer(`tfg:gtceu/mixer/${type}_salvo_with_herbal_slime_ball`)
+			.circuit(4)
+			.itemOutputs(`2x tfg:${type}_salvo`)
+			.itemInputs('gtceu:sticky_resin', `#tfg:${type}_ingredients`, 'jellies:jellie/slime_ball/herbal')
+			.duration(200)
+			.EUt(GTValues.VA[GTValues.LV])
 	})
 
 	//#endregion
 
-	//#region medicine powder recipes
+	//#region Powders
 
 	const powderTypes = [
 		//type			ingredient one		ingredient two
@@ -602,6 +166,7 @@ function registerTFGMedicineRecipes(event) {
 	]
 
 	powderTypes.forEach(type => {
+		// Regular
 		event.recipes.firmalife.mixing_bowl()
 		.ingredients([`#tfg:${type[1]}_ingredients`, `#tfg:${type[2]}_ingredients`, 'minecraft:bone_meal'], Fluid.of('tfg:conifer_pitch', 100))
 		.outputItem(`1x tfg:${type[0]}_powder`)
@@ -615,6 +180,7 @@ function registerTFGMedicineRecipes(event) {
 		.duration(200)
 		.EUt(GTValues.VA[GTValues.LV])
 
+		// With Herbal Slime Ball
 		event.recipes.firmalife.mixing_bowl()
 		.itemIngredients([`#tfg:${type[1]}_ingredients`, `#tfg:${type[2]}_ingredients`, 'jellies:jellie/slime_ball/herbal'])
 		.outputItem(`2x tfg:${type[0]}_powder`)

--- a/kubejs/server_scripts/tfg/primitive/medicine/recipes.medicine.js
+++ b/kubejs/server_scripts/tfg/primitive/medicine/recipes.medicine.js
@@ -614,6 +614,18 @@ function registerTFGMedicineRecipes(event) {
 		.itemInputs(`#tfg:${type[1]}_ingredients`, `#tfg:${type[2]}_ingredients`, 'minecraft:bone_meal')
 		.duration(200)
 		.EUt(GTValues.VA[GTValues.LV])
+
+		event.recipes.firmalife.mixing_bowl()
+		.itemIngredients([`#tfg:${type[1]}_ingredients`, `#tfg:${type[2]}_ingredients`, 'jellies:jellie/slime_ball/herbal'])
+		.outputItem(`2x tfg:${type[0]}_powder`)
+		.id(`tfg:mixing_bowl/${type[0]}_powder_with_herbal_slime_ball`)
+
+		event.recipes.gtceu.mixer(`tfg:gtceu/mixer/${type[0]}_powder_with_herbal_slime_ball`)
+		.circuit(4)
+		.itemOutputs(`2x tfg:${type[0]}_powder`)
+		.itemInputs(`#tfg:${type[1]}_ingredients`, `#tfg:${type[2]}_ingredients`, 'jellies:jellie/slime_ball/herbal')
+		.duration(200)
+		.EUt(GTValues.VA[GTValues.LV])
 	})
 
 	//#endregion

--- a/pakku-lock.json
+++ b/pakku-lock.json
@@ -9891,29 +9891,8 @@
             },
             "files": [
                 {
-                    "type": "curseforge",
-                    "file_name": "Jellies-1.20.1-0.1.0.jar",
-                    "mc_versions": [
-                        "1.20.1"
-                    ],
-                    "loaders": [
-                        "forge"
-                    ],
-                    "release_type": "release",
-                    "url": "https://edge.forgecdn.net/files/8420/106/Jellies-1.20.1-0.1.0.jar",
-                    "id": "8420106",
-                    "parent_id": "1607526",
-                    "hashes": {
-                        "sha1": "809f06ea60b8b2ad358c4aaceae97e4706b88902",
-                        "md5": "6e60de56e040321bc01d180f1ee80f7e"
-                    },
-                    "required_dependencies": [],
-                    "size": 912355,
-                    "date_published": "2026-07-12T17:28:05.937Z"
-                },
-                {
                     "type": "modrinth",
-                    "file_name": "Jellies-1.20.1-0.1.0.jar",
+                    "file_name": "Jellies-1.20.1-0.1.2.jar",
                     "mc_versions": [
                         "1.20.1"
                     ],
@@ -9921,16 +9900,37 @@
                         "forge"
                     ],
                     "release_type": "release",
-                    "url": "https://cdn.modrinth.com/data/9uLmCnkY/versions/pjGw5MNu/Jellies-1.20.1-0.1.0.jar",
-                    "id": "pjGw5MNu",
+                    "url": "https://cdn.modrinth.com/data/9uLmCnkY/versions/YnOI4Kaz/Jellies-1.20.1-0.1.2.jar",
+                    "id": "YnOI4Kaz",
                     "parent_id": "9uLmCnkY",
                     "hashes": {
-                        "sha512": "ee1871e1052e5021e67b47f65fffc5da9a896b131213457ff7dcfdfb842d1eaa97927348057b687deefb94b1571101bb2844ddbaf40380f684f4d9e829ff6146",
-                        "sha1": "809f06ea60b8b2ad358c4aaceae97e4706b88902"
+                        "sha512": "1e6894333c10e80193444c9f618f1856c3280c394f9b6fe6fd13b3f4a315ea54cf3eccc9859f9cccec2f0a8c6fd181fb285aa3530639687939545717f25f3633",
+                        "sha1": "979c197fec4fc4dc94dfd404c4ed6b2da7d3674d"
                     },
                     "required_dependencies": [],
-                    "size": 912355,
-                    "date_published": "2026-07-12T17:28:08.844942Z"
+                    "size": 967180,
+                    "date_published": "2026-07-31T20:14:56.104962Z"
+                },
+                {
+                    "type": "curseforge",
+                    "file_name": "Jellies-1.20.1-0.1.2.jar",
+                    "mc_versions": [
+                        "1.20.1"
+                    ],
+                    "loaders": [
+                        "forge"
+                    ],
+                    "release_type": "release",
+                    "url": "https://edge.forgecdn.net/files/8549/493/Jellies-1.20.1-0.1.2.jar",
+                    "id": "8549493",
+                    "parent_id": "1607526",
+                    "hashes": {
+                        "sha1": "979c197fec4fc4dc94dfd404c4ed6b2da7d3674d",
+                        "md5": "1db4ad7baaaebf1d1d5c04d115129433"
+                    },
+                    "required_dependencies": [],
+                    "size": 967180,
+                    "date_published": "2026-07-31T20:14:54.547Z"
                 }
             ]
         },

--- a/pakku-lock.json
+++ b/pakku-lock.json
@@ -9892,7 +9892,7 @@
             "files": [
                 {
                     "type": "modrinth",
-                    "file_name": "Jellies-1.20.1-0.1.2.jar",
+                    "file_name": "Jellies-1.20.1-0.1.3.jar",
                     "mc_versions": [
                         "1.20.1"
                     ],
@@ -9900,16 +9900,16 @@
                         "forge"
                     ],
                     "release_type": "release",
-                    "url": "https://cdn.modrinth.com/data/9uLmCnkY/versions/YnOI4Kaz/Jellies-1.20.1-0.1.2.jar",
-                    "id": "YnOI4Kaz",
+                    "url": "https://cdn.modrinth.com/data/9uLmCnkY/versions/F2IARDY3/Jellies-1.20.1-0.1.3.jar",
+                    "id": "F2IARDY3",
                     "parent_id": "9uLmCnkY",
                     "hashes": {
-                        "sha512": "1e6894333c10e80193444c9f618f1856c3280c394f9b6fe6fd13b3f4a315ea54cf3eccc9859f9cccec2f0a8c6fd181fb285aa3530639687939545717f25f3633",
-                        "sha1": "979c197fec4fc4dc94dfd404c4ed6b2da7d3674d"
+                        "sha512": "31e6e1559469b2bd004351ea5642ce50d552aff509bb8a7136855f1b4a272a9c9987084f209f8efd7303567b1035f9c39651605fb74f219922be76aed4edd5ac",
+                        "sha1": "df66462c121ec1d305a9e41dc4623f9b8c60c9a9"
                     },
                     "required_dependencies": [],
-                    "size": 967180,
-                    "date_published": "2026-07-31T20:14:56.104962Z"
+                    "size": 967569,
+                    "date_published": "2026-08-01T23:13:43.564278Z"
                 },
                 {
                     "type": "curseforge",

--- a/pakku-lock.json
+++ b/pakku-lock.json
@@ -9913,7 +9913,7 @@
                 },
                 {
                     "type": "curseforge",
-                    "file_name": "Jellies-1.20.1-0.1.2.jar",
+                    "file_name": "Jellies-1.20.1-0.1.3.jar",
                     "mc_versions": [
                         "1.20.1"
                     ],
@@ -9921,16 +9921,16 @@
                         "forge"
                     ],
                     "release_type": "release",
-                    "url": "https://edge.forgecdn.net/files/8549/493/Jellies-1.20.1-0.1.2.jar",
-                    "id": "8549493",
+                    "url": "https://edge.forgecdn.net/files/8557/752/Jellies-1.20.1-0.1.3.jar",
+                    "id": "8557752",
                     "parent_id": "1607526",
                     "hashes": {
-                        "sha1": "979c197fec4fc4dc94dfd404c4ed6b2da7d3674d",
-                        "md5": "1db4ad7baaaebf1d1d5c04d115129433"
+                        "sha1": "df66462c121ec1d305a9e41dc4623f9b8c60c9a9",
+                        "md5": "e79d6a7f5be8806bdaf465fa7264bf19"
                     },
                     "required_dependencies": [],
-                    "size": 967180,
-                    "date_published": "2026-07-31T20:14:54.547Z"
+                    "size": 967569,
+                    "date_published": "2026-08-01T23:13:41.530Z"
                 }
             ]
         },


### PR DESCRIPTION
## What is the new behavior?
Adds new jellies to the spawn pool and their slime ball recipes. Additionally refactored medicine recipe code.

## Implementation Details
- Adds jellie spawn locations based on biomes (only non-earth in this PR).
- Adds Spring and Biotite slime ball recipes.
- Adds appropriate compost tags to Plant and Phosphorum slime balls.
- Adds tags that prevent jellies from dying on other planets.
- Adds buffed output medicine recipes with Herbal slime balls.
- Refactored medicine recipe code to use loops.
- Added `jellies.yaml` config with default settings that can be changed to balance them out.

## Additional Information
- Had to modify `.gitignore` because the config was not being staged, hope that is fine.
- As with the Core's PR, I do not know if these locations are good for the jellies.
- I will work on jellie Patchouli stuff once @Redeix is finished with it.
- Eevee jellie is currently unobtainable due to the lack of Starcatcher.

## Companion PRs:
- Core: https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/546