### PR TITLE
mild methane rebalance for convenience

### DIFF
--- a/kubejs/server_scripts/tfg/powergen/recipes.power_gen_balance.js
+++ b/kubejs/server_scripts/tfg/powergen/recipes.power_gen_balance.js
@@ -38,6 +38,17 @@ function registerTFGPowerGenBalance(event) {
         .dimension('minecraft:overworld')
 		.dimension('minecraft:the_nether')
 
+	// Adjust methane
+
+	event.remove({ id: 'gtceu:gas_turbine/methane' })
+
+	event.recipes.gtceu.gas_turbine('tfg:methane') // Gas Turbine
+		.inputFluids(Fluid.of('gtceu:methane', 1))
+		.EUt(-(32))
+		.duration(20*0.15)
+		.dimension('minecraft:overworld')
+		.dimension('minecraft:the_nether')
+
     // Remove Light fuel ability as a fuel
 
 	event.remove({ id: 'gtceu:combustion_generator/sulfuric_light_fuel' })


### PR DESCRIPTION
lowering the duration of methane from 7 to 3 ticks in the gas turbine, but reducing the amount consumed from 2 to 1
this is technically a mild nerf to the energy of methane, but it prevents cases where a gas turbine may be clogged with 1 mb of methane.

this seems fair as methane is a byproduct usually burned in conjunction with LPG, this is simply to make that possible without clogging