### PR TITLE
TFC Camel Backport (Modpack)

### DIFF
--- a/kubejs/server_scripts/tfg/food/tags.food.js
+++ b/kubejs/server_scripts/tfg/food/tags.food.js
@@ -334,6 +334,9 @@ function registerTFGFoodItemTags(event) {
 	event.add('tfc:rabbit_food', 'minecraft:chorus_fruit')
 	event.add('tfc:rabbit_food', 'minecraft:popped_chorus_fruit')
 
+	event.add('tfg:camel_food', '#tfc:foods/grains')
+	event.add('tfg:camel_food', '#tfc:foods/fruits')
+
 	event.add('tfc:foods', 'ad_astra:cheese')
 	event.add('tfc:foods/dairy', 'ad_astra:cheese')
 	event.add('tfc:foods/usable_in_sandwich', 'ad_astra:cheese')

--- a/kubejs/server_scripts/tfg/loot.js
+++ b/kubejs/server_scripts/tfg/loot.js
@@ -247,6 +247,30 @@ function registerTFGLoots(event) {
 		.addWeightedLoot([1, 3], ['minecraft:bone'])
 		.addLoot(LootEntry.of('tfc:small_raw_hide', 1))
 
+	// Bactrian camel normal loot table
+	event.addEntityLootModifier('tfg:bactrian_camel')
+		.addWeightedLoot([13, 19], ['tfc:food/camelidae'])
+		.addWeightedLoot([1, 4], ['minecraft:bone'])
+		.addLoot(LootEntry.of('tfc:large_sheepskin_hide', 1))
+		.addSequenceLoot(LootEntry.of('waterflasks:bladder').when(c => c.randomChance(0.5)))
+
+	// Bactrian camel drop extra with butchery knife
+	event.addEntityLootModifier('tfg:bactrian_camel')
+		.matchMainHand('#forge:tools/butchery_knives')
+		.addWeightedLoot([3, 5], ['tfc:food/camelidae'])
+
+	// Dromedary camel normal loot table
+	event.addEntityLootModifier('tfg:dromedary_camel')
+		.addWeightedLoot([13, 19], ['tfc:food/camelidae'])
+		.addWeightedLoot([1, 4], ['minecraft:bone'])
+		.addLoot(LootEntry.of('tfc:large_raw_hide', 1))
+		.addSequenceLoot(LootEntry.of('waterflasks:bladder').when(c => c.randomChance(0.5)))
+
+	// Dromedary camel drop extra with butchery knife
+	event.addEntityLootModifier('tfg:dromedary_camel')
+		.matchMainHand('#forge:tools/butchery_knives')
+		.addWeightedLoot([3, 5], ['tfc:food/camelidae'])
+
 	// Tamed Fox normal loot table
 	event.addEntityLootModifier('tfg:fox')
 		.addLoot(LootEntry.of('tfc:small_raw_hide', 1))

--- a/kubejs/server_scripts/tfg/overworld/tags.overworld.js
+++ b/kubejs/server_scripts/tfg/overworld/tags.overworld.js
@@ -143,9 +143,16 @@ function registerTFGOverworldBlockTags(event) {
 	event.add("tfc:monster_spawns_on", "minecraft:packed_ice");
 	event.add("tfc:monster_spawns_on", "minecraft:blue_ice");
 
-	event.add('tfg:camel_faster_on', '#tfc:coarse_dirt')
-	event.add('tfg:camel_faster_on', '#forge:gravels')
-	event.add('tfg:camel_faster_on', '#forge:sands')
+	event.add('tfg:camel_faster_on', 'tfg:coarse_dirt/silty_loam')
+	event.add('tfg:camel_faster_on', 'tfg:coarse_dirt/sandy_loam')
+	event.add('tfg:camel_faster_on', 'tfg:coarse_dirt/silt')
+	event.add('tfg:camel_faster_on', 'tfg:coarse_dirt/loam')
+	event.add('tfg:camel_faster_on', 'tfg:coarse_dirt/alfisol')
+	event.add('tfg:camel_faster_on', 'tfg:coarse_dirt/mollisol')
+	event.add('tfg:camel_faster_on', 'tfg:coarse_dirt/oxisol')
+	event.add('tfg:camel_faster_on', 'tfg:coarse_dirt/podzol')
+	event.add('tfg:camel_faster_on', '#forge:gravel')
+	event.add('tfg:camel_faster_on', '#forge:sand')
 	event.add('tfg:camel_faster_on', 'tfc:raw_sandstone/brown')
 	event.add('tfg:camel_faster_on', 'tfc:raw_sandstone/white')
 	event.add('tfg:camel_faster_on', 'tfc:raw_sandstone/black')

--- a/kubejs/server_scripts/tfg/overworld/tags.overworld.js
+++ b/kubejs/server_scripts/tfg/overworld/tags.overworld.js
@@ -142,6 +142,17 @@ function registerTFGOverworldBlockTags(event) {
 	event.add("tfc:monster_spawns_on", "tfg:pelitic_hornfels");
 	event.add("tfc:monster_spawns_on", "minecraft:packed_ice");
 	event.add("tfc:monster_spawns_on", "minecraft:blue_ice");
+
+	event.add('tfg:camel_faster_on', '#tfc:coarse_dirt')
+	event.add('tfg:camel_faster_on', '#forge:gravels')
+	event.add('tfg:camel_faster_on', '#forge:sands')
+	event.add('tfg:camel_faster_on', 'tfc:raw_sandstone/brown')
+	event.add('tfg:camel_faster_on', 'tfc:raw_sandstone/white')
+	event.add('tfg:camel_faster_on', 'tfc:raw_sandstone/black')
+	event.add('tfg:camel_faster_on', 'tfc:raw_sandstone/red')
+	event.add('tfg:camel_faster_on', 'tfc:raw_sandstone/yellow')
+	event.add('tfg:camel_faster_on', 'tfc:raw_sandstone/green')
+	event.add('tfg:camel_faster_on', 'tfc:raw_sandstone/pink')
 }
 
 function registerTFGOverworldBiomeTags(event) {

--- a/kubejs/server_scripts/tfg/overworld/tags.overworld.js
+++ b/kubejs/server_scripts/tfg/overworld/tags.overworld.js
@@ -583,6 +583,8 @@ function registerTFGOverworldEntityTypeTags(event) {
 	event.add('tfg:ignores_cacti', 'tfc:horse')
 	event.add('tfg:ignores_cacti', 'tfc:donkey')
 	event.add('tfg:ignores_cacti', 'tfc:mule')
+	event.add('tfg:ignores_cacti', 'tfg:dromedary_camel')
+	event.add('tfg:ignores_cacti', 'tfg:bactrian_camel')
 
 	event.add('tfc:amphibious_creatures', 'tfg:leopard_seal')
 	event.add('tfc:spawns_on_cold_blocks', 'tfg:leopard_seal')
@@ -592,6 +594,8 @@ function registerTFGOverworldEntityTypeTags(event) {
 	event.add('tfc:hunted_by_ocean_predators', 'tfc:turtle')
 
 	event.add('tfc:land_prey', 'tfg:leopard_seal')
+	event.add('tfc:land_prey', 'tfg:dromedary_camel')
+	event.add('tfc:land_prey', 'tfg:bactrian_camel')
 	event.add('tfc:land_prey', '#jellies:jellie')
 
 	event.add('tfc:hunted_by_dogs', 'tfg:jerboa')
@@ -604,4 +608,9 @@ function registerTFGOverworldEntityTypeTags(event) {
 	event.add('tfg:not_rammed_by_rammers', '#tfc:bubble_column_immune')
 	event.add('tfg:not_rammed_by_rammers', '#tfc:pests')
 	event.add('tfg:not_rammed_by_rammers', 'tfc:frog')
+
+	event.add('tfg:ramming_animals', 'tfc:boar')
+	event.add('tfg:ramming_animals', 'tfc:moose')
+	event.add('tfg:ramming_animals', 'tfc:wildebeest')
+	event.add('tfg:ramming_animals', 'tfg:bison')
 }

--- a/kubejs/server_scripts/tfg/worldgen/data.fauna.js
+++ b/kubejs/server_scripts/tfg/worldgen/data.fauna.js
@@ -63,6 +63,26 @@ function registerTFGFauna(event) {
 		},
 		"tfg:mongoose")
 
+	event.fauna(
+		climate => {
+			climate.minTemp(-5)
+			climate.maxRain(100)
+		},
+		faunaData => {
+			faunaData.solidGround(true)
+		},
+		"tfg:dromedary_camel")
+
+	event.fauna(
+		climate => {
+			climate.maxTemp(-5)
+			climate.maxRain(100)
+		},
+		faunaData => {
+			faunaData.solidGround(true)
+		},
+		"tfg:bactrian_camel")
+
 	// Jellies
 	event.fauna(
 		climate => {

--- a/kubejs/startup_scripts/tfg/worldgen/fauna.js
+++ b/kubejs/startup_scripts/tfg/worldgen/fauna.js
@@ -9,6 +9,8 @@ TFCEvents.registerFaunas(event => {
 	event.replace("tfg:jerboa", $SpawnPlacements.Type.ON_GROUND, "ocean_floor");
 	event.replace("tfg:lemming", $SpawnPlacements.Type.ON_GROUND, "ocean_floor");
 	event.replace("tfg:mongoose", $SpawnPlacements.Type.ON_GROUND, "ocean_floor");
+	event.replace("tfg:dromedary_camel", $SpawnPlacements.Type.ON_GROUND, "ocean_floor");
+	event.replace("tfg:bactrian_camel", $SpawnPlacements.Type.ON_GROUND, "ocean_floor");
 	event.replace("tfg:leopard_seal", $SpawnPlacements.Type.NO_RESTRICTIONS, "ocean_floor");
 	
 	event.replace("jellies:herbal", $SpawnPlacements.Type.NO_RESTRICTIONS, "motion_blocking_no_leaves");


### PR DESCRIPTION
## What is the new behavior?
Adds tags, fauna and loot for both camels. Additionally, added `ramming_animals` tag to rammers for avoidance brain AI.

## Companion PRs:
- Core: https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/548
- Tools: https://github.com/TerraFirmaGreg-Team/Tools-Modern/pull/508