### PR TITLE
Changed silk clothing repair recipe to use tags

### DIFF
--- a/kubejs/server_scripts/tfg/equipment/recipes.repair.js
+++ b/kubejs/server_scripts/tfg/equipment/recipes.repair.js
@@ -77,11 +77,6 @@ function registerTFGRepairRecipes(event) {
 		{ item: "tfcambiental:wool_pants", material: "tfc:wool_cloth" },
 		{ item: "tfcambiental:wool_boots", material: "tfc:wool_cloth" },
 
-		{ item: "tfcambiental:silk_cowl", material: "tfc:silk_cloth" },
-		{ item: "tfcambiental:silk_shirt", material: "tfc:silk_cloth" },
-		{ item: "tfcambiental:silk_pants", material: "tfc:silk_cloth" },
-		{ item: "tfcambiental:silk_shoes", material: "tfc:silk_cloth" },
-
 		{ item: "tfc_textile:linen_hat", material: "tfg:linen_cloth" },
 		{ item: "tfc_textile:linen_shirt", material: "tfg:linen_cloth" },
 		{ item: "tfc_textile:linen_pants", material: "tfg:linen_cloth" },
@@ -97,7 +92,11 @@ function registerTFGRepairRecipes(event) {
 
 	const SPECIAL_TAG_REPAIRS = [
 		{ item: "hangglider:hang_glider", tag: "forge:cloth" },
-		{ item: "hangglider:reinforced_hang_glider", tag: "tfg:lightweight_cloth" }
+		{ item: "hangglider:reinforced_hang_glider", tag: "tfg:lightweight_cloth" },
+		{ item: "tfcambiental:silk_cowl", tag: "tfg:lightweight_cloth" },
+		{ item: "tfcambiental:silk_shirt", tag: "tfg:lightweight_cloth" },
+		{ item: "tfcambiental:silk_pants", tag: "tfg:lightweight_cloth" },
+		{ item: "tfcambiental:silk_shoes", tag: "tfg:lightweight_cloth" }
 	]
 
 	repairColoredSteel('gtceu', 'red_steel');


### PR DESCRIPTION
Allows for repair of silk clothing with items with the tfg:lightweight_cloth tag which matches the material used to make it.

## What is the new behavior?
Changed the material repair recipe for silk clothing to match the materials used in creation. Allows repair with phantom silk and polycaprolactam fabric in addition to regular silk. 

## Implementation Details
Only a simple json change in kubejs/server_scripts/tfg/equipment/recipes.repair.js. Moved silk repair from SPECIAL_REPAIRS to SPACIAL_TAG_REPAIRS


**Discord name: Kvarok**
