### PR TITLE
Added quests for different support options. Fixed drum/crate quests to accept alternative bronze variants

### DIFF
--- a/config/ftbquests/quests/chapters/questsmetallurgy.snbt
+++ b/config/ftbquests/quests/chapters/questsmetallurgy.snbt
@@ -1819,6 +1819,64 @@
 			x: 9.5d
 			y: -36.0d
 		}
+		{
+			dependencies: ["2936976FC773ABE4"]
+			description: ["{quests.tfg_tips.create_concrete_support.desc}"]
+			icon: "tfg:light_concrete_support"
+			id: "21FB1C0595EAC316"
+			optional: true
+			shape: "heart"
+			subtitle: "{quests.tfg_tips.create_concrete_support.subtitle}"
+			tasks: [{
+				id: "4F2AC7CA093C30BD"
+				item: {
+					Count: 1
+					id: "ftbfiltersystem:smart_filter"
+					tag: {
+						"ftbfiltersystem:filter": "or(item(tfg:light_concrete_support)item(tfg:dark_concrete_support))"
+					}
+				}
+				title: "{quests.tfg_tips.create_concrete_support.task0}"
+				type: "item"
+			}]
+			title: "{quests.tfg_tips.create_concrete_support.title}"
+			x: -4.5d
+			y: -30.5d
+		}
+		{
+			dependencies: ["04DE7C58F20B535A"]
+			description: ["{quests.tfg_tips.create_reinforced_concrete_support.desc}"]
+			id: "620DEF4A7F08EE15"
+			optional: true
+			shape: "heart"
+			subtitle: "{quests.tfg_tips.create_reinforced_concrete_support.subtitle}"
+			tasks: [
+				{
+					id: "7753818267F79DA7"
+					item: {
+						Count: 1
+						id: "ftbfiltersystem:smart_filter"
+						tag: {
+							display: {
+								Name: "{\"text\":\"rf\"}"
+							}
+							"ftbfiltersystem:filter": "or(item(tfg:reinforced_light_concrete_support)item(tfg:reinforced_dark_concrete_support))"
+						}
+					}
+					title: "{quests.tfg_tips.create_reinforced_concrete_support.task0}"
+					type: "item"
+				}
+				{
+					id: "5A3CFB31F6A7A51C"
+					item: "tfg:steel_support"
+					title: "{quests.tfg_tips.create_reinforced_concrete_support.task1}"
+					type: "item"
+				}
+			]
+			title: "{quests.tfg_tips.create_reinforced_concrete_support.title}"
+			x: 28.5d
+			y: -31.0d
+		}
 	]
 	subtitle: ["{quests.metal_age.subtitle}"]
 	title: "{quests.metal_age}"

--- a/config/ftbquests/quests/chapters/questsmetallurgy.snbt
+++ b/config/ftbquests/quests/chapters/questsmetallurgy.snbt
@@ -1836,7 +1836,7 @@
 						"ftbfiltersystem:filter": "or(item(tfg:light_concrete_support)item(tfg:dark_concrete_support))"
 					}
 				}
-				title: "{quests.tfg_tips.create_concrete_support.task0}"
+				title: "{quests.tfg_tips.create_concrete_support.task}"
 				type: "item"
 			}]
 			title: "{quests.tfg_tips.create_concrete_support.title}"
@@ -1863,13 +1863,13 @@
 							"ftbfiltersystem:filter": "or(item(tfg:reinforced_light_concrete_support)item(tfg:reinforced_dark_concrete_support))"
 						}
 					}
-					title: "{quests.tfg_tips.create_reinforced_concrete_support.task0}"
+					title: "{quests.tfg_tips.create_reinforced_concrete_support.task.0}"
 					type: "item"
 				}
 				{
 					id: "5A3CFB31F6A7A51C"
 					item: "tfg:steel_support"
-					title: "{quests.tfg_tips.create_reinforced_concrete_support.task1}"
+					title: "{quests.tfg_tips.create_reinforced_concrete_support.task.1}"
 					type: "item"
 				}
 			]

--- a/config/ftbquests/quests/chapters/questssteam_age.snbt
+++ b/config/ftbquests/quests/chapters/questssteam_age.snbt
@@ -1109,7 +1109,7 @@
 					Count: 1
 					id: "ftbfiltersystem:smart_filter"
 					tag: {
-						"ftbfiltersystem:filter": "or(item(gtceu:bronze_drum)item(gtceu:steel_drum)item(gtceu:aluminium_drum)item(gtceu:stainless_steel_drum)item(gtceu:gold_drum)item(gtceu:titanium_drum)item(gtceu:tungsten_steel_drum))"
+						"ftbfiltersystem:filter": "or(item(gtceu:bronze_drum)item(gtceu:steel_drum)item(gtceu:aluminium_drum)item(gtceu:stainless_steel_drum)item(gtceu:gold_drum)item(gtceu:titanium_drum)item(gtceu:tungsten_steel_drum)item(gtceu:bismuth_bronze_drum)item(gtceu:black_bronze_drum))"
 					}
 				}
 				title: "{quests.tasktype.item.any}"

--- a/config/ftbquests/quests/chapters/questssteam_age.snbt
+++ b/config/ftbquests/quests/chapters/questssteam_age.snbt
@@ -1112,7 +1112,7 @@
 						"ftbfiltersystem:filter": "or(item(gtceu:bronze_drum)item(gtceu:steel_drum)item(gtceu:aluminium_drum)item(gtceu:stainless_steel_drum)item(gtceu:gold_drum)item(gtceu:titanium_drum)item(gtceu:tungsten_steel_drum)item(gtceu:bismuth_bronze_drum)item(gtceu:black_bronze_drum))"
 					}
 				}
-				title: "{quests.tasktype.item.any}"
+				title: "{quests.steam_age.fluid_drums.task}"
 				type: "item"
 			}]
 			title: "{quests.steam_age.fluid_drums.title}"

--- a/config/ftbquests/quests/chapters/tips__tools.snbt
+++ b/config/ftbquests/quests/chapters/tips__tools.snbt
@@ -623,7 +623,7 @@
 					Count: 1
 					id: "ftbfiltersystem:smart_filter"
 					tag: {
-						"ftbfiltersystem:filter": "or(item(gtceu:wood_crate)item(gtceu:bronze_crate)item(gtceu:steel_crate)item(gtceu:aluminium_crate)item(gtceu:stainless_steel_crate)item(gtceu:titanium_crate)item(gtceu:tungsten_steel_crate))"
+						"ftbfiltersystem:filter": "or(item(gtceu:wood_crate)item(gtceu:bronze_crate)item(gtceu:steel_crate)item(gtceu:aluminium_crate)item(gtceu:stainless_steel_crate)item(gtceu:titanium_crate)item(gtceu:tungsten_steel_crate)item(gtceu:bismuth_bronze_crate)item(gtceu:black_bronze_crate))"
 					}
 				}
 				type: "item"

--- a/config/ftbquests/quests/chapters/tips__tools.snbt
+++ b/config/ftbquests/quests/chapters/tips__tools.snbt
@@ -626,6 +626,7 @@
 						"ftbfiltersystem:filter": "or(item(gtceu:wood_crate)item(gtceu:bronze_crate)item(gtceu:steel_crate)item(gtceu:aluminium_crate)item(gtceu:stainless_steel_crate)item(gtceu:titanium_crate)item(gtceu:tungsten_steel_crate)item(gtceu:bismuth_bronze_crate)item(gtceu:black_bronze_crate))"
 					}
 				}
+				title: "{quests.tfg_tips.crates.task}"
 				type: "item"
 			}]
 			title: "{quests.tfg_tips.crates.title}"


### PR DESCRIPTION
## What is the new behavior?
https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/4668
Fixed drum/crate quests to accept alternative bronze variants

Followup to: https://github.com/TerraFirmaGreg-Team/Tools-Modern/pull/513

## Implementation Details
PR is very small, everything was discussed on discord

## Additional Information
Screenshots
<img width="407" height="370" alt="image" src="https://github.com/user-attachments/assets/cd801404-1099-40cc-a1f4-424516140024" />
<img width="449" height="371" alt="image" src="https://github.com/user-attachments/assets/0d66587b-4062-453d-b2ca-ac238ed36140" />
<img width="449" height="371" alt="image" src="https://github.com/user-attachments/assets/74d83b2b-607c-4bc9-9193-1b573c4e8006" />
<img width="419" height="424" alt="image" src="https://github.com/user-attachments/assets/003751a8-76fe-454f-bf4c-189f1a7de361" />

discord: dxthwsh