### PR TITLE
Changed misformed 'task[0-9]' to 'task.[0-9]'

### DIFF
--- a/config/ftbquests/quests/chapters/hv__high_voltage.snbt
+++ b/config/ftbquests/quests/chapters/hv__high_voltage.snbt
@@ -1318,7 +1318,7 @@
 						}
 					}
 					match_nbt: false
-					title: "{quests.high_voltage.gun.task1}"
+					title: "{quests.high_voltage.gun.task.1}"
 					type: "item"
 				}
 				{
@@ -1331,7 +1331,7 @@
 						}
 					}
 					optional_task: true
-					title: "{quests.high_voltage.gun.task2}"
+					title: "{quests.high_voltage.gun.task.2}"
 					type: "item"
 				}
 				{

--- a/config/ftbquests/quests/chapters/questsmetallurgy.snbt
+++ b/config/ftbquests/quests/chapters/questsmetallurgy.snbt
@@ -1028,7 +1028,7 @@
 							"ftbfiltersystem:filter": "or(item(gtceu:nickel_ingot)item(gtceu:nickel_dust))"
 						}
 					}
-					title: "{quests.metal_age.weak_steel.task1}"
+					title: "{quests.metal_age.weak_steel.task.1}"
 					type: "item"
 					weak_nbt_match: true
 				}
@@ -1042,7 +1042,7 @@
 							"ftbfiltersystem:filter": "or(item(gtceu:steel_ingot)item(gtceu:steel_dust))"
 						}
 					}
-					title: "{quests.metal_age.weak_steel.task2}"
+					title: "{quests.metal_age.weak_steel.task.2}"
 					type: "item"
 					weak_nbt_match: true
 				}
@@ -1055,7 +1055,7 @@
 							"ftbfiltersystem:filter": "or(item(gtceu:black_bronze_ingot)item(gtceu:black_bronze_dust))"
 						}
 					}
-					title: "{quests.metal_age.weak_steel.task3}"
+					title: "{quests.metal_age.weak_steel.task.3}"
 					type: "item"
 					weak_nbt_match: true
 				}

--- a/config/ftbquests/quests/chapters/tips__combat.snbt
+++ b/config/ftbquests/quests/chapters/tips__combat.snbt
@@ -1083,7 +1083,7 @@
 							"ftbfiltersystem:filter": "or(item(tfc:metal/helmet/bismuth_bronze)item(tfc:metal/helmet/black_bronze)item(tfc:metal/helmet/bronze)item(tfc:metal/helmet/copper)item(tfc:metal/helmet/wrought_iron)item(tfc:metal/helmet/steel)item(tfc:metal/helmet/black_steel)item(tfc:metal/helmet/blue_steel)item(tfc:metal/helmet/red_steel))"
 						}
 					}
-					title: "{quests.combat_tips.armor.task1}"
+					title: "{quests.combat_tips.armor.task.1}"
 					type: "item"
 				}
 				{
@@ -1095,7 +1095,7 @@
 							"ftbfiltersystem:filter": "or(item(tfc:metal/chestplate/bismuth_bronze)item(tfc:metal/chestplate/black_bronze)item(tfc:metal/chestplate/bronze)item(tfc:metal/chestplate/copper)item(tfc:metal/chestplate/wrought_iron)item(tfc:metal/chestplate/steel)item(tfc:metal/chestplate/black_steel)item(tfc:metal/chestplate/blue_steel)item(tfc:metal/chestplate/red_steel))"
 						}
 					}
-					title: "{quests.combat_tips.armor.task2}"
+					title: "{quests.combat_tips.armor.task.2}"
 					type: "item"
 				}
 				{
@@ -1107,7 +1107,7 @@
 							"ftbfiltersystem:filter": "or(item(tfc:metal/greaves/bismuth_bronze)item(tfc:metal/greaves/black_bronze)item(tfc:metal/greaves/bronze)item(tfc:metal/greaves/copper)item(tfc:metal/greaves/wrought_iron)item(tfc:metal/greaves/steel)item(tfc:metal/greaves/black_steel)item(tfc:metal/greaves/blue_steel)item(tfc:metal/greaves/red_steel))"
 						}
 					}
-					title: "{quests.combat_tips.armor.task3}"
+					title: "{quests.combat_tips.armor.task.3}"
 					type: "item"
 				}
 				{
@@ -1119,7 +1119,7 @@
 							"ftbfiltersystem:filter": "or(item(tfc:metal/boots/bismuth_bronze)item(tfc:metal/boots/black_bronze)item(tfc:metal/boots/bronze)item(tfc:metal/boots/copper)item(tfc:metal/boots/wrought_iron)item(tfc:metal/boots/steel)item(tfc:metal/boots/black_steel)item(tfc:metal/boots/blue_steel)item(tfc:metal/boots/red_steel))"
 						}
 					}
-					title: "{quests.combat_tips.armor.task4}"
+					title: "{quests.combat_tips.armor.task.4}"
 					type: "item"
 				}
 			]
@@ -1326,7 +1326,7 @@
 						}
 					}
 					optional_task: true
-					title: "{quests.combat_tips.bow.task2}"
+					title: "{quests.combat_tips.bow.task.2}"
 					type: "item"
 				}
 			]
@@ -1386,7 +1386,7 @@
 							"ftbfiltersystem:filter": "ftbfiltersystem:item_tag(tfc:swords)"
 						}
 					}
-					title: "{quests.combat_tips.mold_weapons.task1}"
+					title: "{quests.combat_tips.mold_weapons.task.1}"
 					type: "item"
 				}
 				{
@@ -1398,7 +1398,7 @@
 							"ftbfiltersystem:filter": "ftbfiltersystem:item_tag(tfc:scythes)"
 						}
 					}
-					title: "{quests.combat_tips.mold_weapons.task2}"
+					title: "{quests.combat_tips.mold_weapons.task.2}"
 					type: "item"
 				}
 				{
@@ -1410,7 +1410,7 @@
 							"ftbfiltersystem:filter": "ftbfiltersystem:item_tag(tfc:maces)"
 						}
 					}
-					title: "{quests.combat_tips.mold_weapons.task3}"
+					title: "{quests.combat_tips.mold_weapons.task.3}"
 					type: "item"
 				}
 			]

--- a/config/ftbquests/quests/chapters/tips__tools.snbt
+++ b/config/ftbquests/quests/chapters/tips__tools.snbt
@@ -2862,7 +2862,7 @@
 							"ftbfiltersystem:filter": "item_tag(rnr:mattocks)"
 						}
 					}
-					title: "{quests.tfg_tips.tools_tips.mattocks.task0}"
+					title: "{quests.tfg_tips.tools_tips.mattocks.task.0}"
 					type: "item"
 				}
 				{
@@ -2876,7 +2876,7 @@
 						}
 					}
 					optional_task: true
-					title: "{quests.tfg_tips.tools_tips.mattocks.task1}"
+					title: "{quests.tfg_tips.tools_tips.mattocks.task.1}"
 					type: "item"
 				}
 			]


### PR DESCRIPTION
##What is the new behavior?
Uniforming quest files to use only 'task.[tasknumber]' form, instead of 'task[tasknumber]' and 'task.[tasknumber]'
Followup to: https://github.com/TerraFirmaGreg-Team/Tools-Modern/pull/514

##Implementation Details
Simple sed operation

discord: dxthwsh