### PR TITLE
Jellie Spawn Change and Nutritional Mash

### DIFF
--- a/config/jellies.yaml
+++ b/config/jellies.yaml
@@ -462,3 +462,36 @@ entities:
     # Default: 32
     gestationDays: 16
 
+  tetoJellie:
+    # Maximum familiarity that a wild jellie can reach.
+    # Default: 1
+    familiarityCap: 1.0
+
+    # How many days it takes a jellie to reach adulthood.
+    # Default: 16
+    adulthoodDays: 16
+
+    # How many uses a jellie has before becoming old.
+    # Default: 120
+    uses: 120
+
+    # Does jellie eat rotten food.
+    # Default: false
+    eatsRottenFood: false
+
+    # How long it takes for a jellie to produce products.
+    # Default: 23500
+    produceTicks: 23500
+
+    # Minimum familiarity needed for jellie to produce products.
+    # Default: 0.15
+    produceFamiliarity: 0.15
+
+    # How many children a jellie can have at once.
+    # Default: 1
+    childCount: 2
+
+    # How long it takes for a jellie to be born.
+    # Default: 32
+    gestationDays: 16
+

--- a/kubejs/data/tfg/worldgen/biome/mars/martian_deep_desert.json
+++ b/kubejs/data/tfg/worldgen/biome/mars/martian_deep_desert.json
@@ -75,8 +75,8 @@
 		}
 	},
 	"spawners": {
-		
-		"ambient": [
+		"ambient": [],
+		"axolotls": [
 			{
 				"type": "jellies:pentetic",
 				"maxCount": 2,
@@ -84,7 +84,6 @@
 				"weight": 100
 			}
 		],
-		"axolotls": [],
 		"creature": [
 			{
 				"type": "species:stackatick",

--- a/kubejs/data/tfg/worldgen/biome/mars/martian_mountains.json
+++ b/kubejs/data/tfg/worldgen/biome/mars/martian_mountains.json
@@ -110,7 +110,8 @@
 		}
 	},
 	"spawners": {
-		"ambient": [
+		"ambient": [],
+		"axolotls": [
 			{
 				"type": "jellies:pentetic",
 				"maxCount": 2,
@@ -118,7 +119,6 @@
 				"weight": 100
 			}
 		],
-		"axolotls": [],
 		"creature": [
 			{
 				"type": "tfg:wraptor",

--- a/kubejs/data/tfg/worldgen/biome/moon/lunar_asurine_dense.json
+++ b/kubejs/data/tfg/worldgen/biome/moon/lunar_asurine_dense.json
@@ -76,7 +76,8 @@
 		}
 	},
 	"spawners": {
-		"ambient": [
+		"ambient": [],
+		"axolotls": [
 			{
 				"type": "jellies:certus",
 				"maxCount": 1,
@@ -84,7 +85,6 @@
 				"weight": 100
 			}
 		],
-		"axolotls": [],
 		"creature": [
 			{
 				"type": "species:birt",

--- a/kubejs/data/tfg/worldgen/biome/moon/lunar_asurine_sparse.json
+++ b/kubejs/data/tfg/worldgen/biome/moon/lunar_asurine_sparse.json
@@ -80,7 +80,8 @@
 		}
 	},
 	"spawners": {
-		"ambient": [
+		"ambient": [],
+		"axolotls": [
 			{
 				"type": "jellies:certus",
 				"maxCount": 1,
@@ -88,7 +89,6 @@
 				"weight": 100
 			}
 		],
-		"axolotls": [],
 		"creature": [
 			{
 				"type": "tfg:moon_rabbit",

--- a/kubejs/server_scripts/jellies/recipes.js
+++ b/kubejs/server_scripts/jellies/recipes.js
@@ -2,6 +2,23 @@
 "use strict";
 
 function registerJelliesRecipes(event) {
+	// Jellie Nutritional Mash
+	event.shaped('4x jellies:jellie/food/nutritional_mash', [
+		' A ',
+		'ABA',
+		' A '
+	], {
+		A: '#tfg:items/jellie_nutritional_mash_ingredient',
+		B: '#forge:tools/mortars'
+	}).id('tfg:shaped/jellies_nutritional_mash')
+
+	event.recipes.gtceu.mixer('tfg:jellies_nutritional_mash')
+		.circuit(8)
+		.itemInputs('#tfg:items/jellie_nutritional_mash_ingredient', '#tfg:items/jellie_nutritional_mash_ingredient', '#tfg:items/jellie_nutritional_mash_ingredient', '#tfg:items/jellie_nutritional_mash_ingredient')
+		.itemOutputs('4x jellies:jellie/food/nutritional_mash')
+		.duration(100)
+		.EUt(GTValues.VA[GTValues.LV])
+
 	// Jellie Slime Ball to Minecraft Slime Ball
 	event.custom({
 		type: "ae2:transform",

--- a/kubejs/server_scripts/jellies/tags.js
+++ b/kubejs/server_scripts/jellies/tags.js
@@ -2,8 +2,38 @@
 "use strict";
 
 function registerJelliesItemTags(event) {
-	event.add("jellies:jellie/slime_ball/plant", "#tfc:compost_greens_high")
-	event.add("jellies:jellie/slime_ball/phosphorum", "#tfc:compost_browns_high")
+	const NUTRITIONAL_MASH_INGREDIENTS = [
+		// Overall Liked
+		'#tfc:foods/fruits',
+		'#forge:mushrooms',
+
+		// Moon
+		'minecraft:ochre_froglight',
+		'minecraft:verdant_froglight',
+		'minecraft:pearlescent_froglight',
+		'species:birt_egg',
+
+		// Mars
+		'tfg:saplings/alphacene',
+		'tfg:saplings/strophar',
+		'tfg:saplings/aeronos',
+		'tfg:saplings/glacian',
+		'betterend:aurant_polypore',
+		'betterend:purple_polypore'
+	]
+
+	NUTRITIONAL_MASH_INGREDIENTS.forEach(ingredient => {
+		event.add('tfg:items/jellie_nutritional_mash_ingredient', ingredient)
+	})
+
+
+	event.add("tfg:items/jellie_nutritional_mash_ingredient", "#beneath:mushrooms")
+	event.add("tfg:items/jellie_nutritional_mash_ingredient", "#beneath:mushrooms")
+	event.add("tfg:items/jellie_nutritional_mash_ingredient", "#beneath:mushrooms")
+	event.add("tfg:items/jellie_nutritional_mash_ingredient", "#beneath:mushrooms")
+
+	event.add('tfc:compost_greens_high', 'jellies:jellie/slime_ball/plant')
+	event.add('tfc:compost_browns_high', 'jellies:jellie/slime_ball/phosphorum')
 }
 
 function registerJelliesEntityTags(event) {

--- a/kubejs/server_scripts/jellies/tags.js
+++ b/kubejs/server_scripts/jellies/tags.js
@@ -2,7 +2,6 @@
 "use strict";
 
 function registerJelliesItemTags(event) {
-	event.add("jellies:jellie_food", "#forge:mushrooms");
 	event.add("jellies:jellie/slime_ball/plant", "#tfc:compost_greens_high")
 	event.add("jellies:jellie/slime_ball/phosphorum", "#tfc:compost_browns_high")
 }

--- a/kubejs/server_scripts/jellies/tags.js
+++ b/kubejs/server_scripts/jellies/tags.js
@@ -14,6 +14,8 @@ function registerJelliesItemTags(event) {
 		'species:birt_egg',
 
 		// Mars
+		'tfg:saplings/crimson',
+		'tfg:saplings/warped',
 		'tfg:saplings/alphacene',
 		'tfg:saplings/strophar',
 		'tfg:saplings/aeronos',
@@ -25,12 +27,6 @@ function registerJelliesItemTags(event) {
 	NUTRITIONAL_MASH_INGREDIENTS.forEach(ingredient => {
 		event.add('tfg:items/jellie_nutritional_mash_ingredient', ingredient)
 	})
-
-
-	event.add("tfg:items/jellie_nutritional_mash_ingredient", "#beneath:mushrooms")
-	event.add("tfg:items/jellie_nutritional_mash_ingredient", "#beneath:mushrooms")
-	event.add("tfg:items/jellie_nutritional_mash_ingredient", "#beneath:mushrooms")
-	event.add("tfg:items/jellie_nutritional_mash_ingredient", "#beneath:mushrooms")
 
 	event.add('tfc:compost_greens_high', 'jellies:jellie/slime_ball/plant')
 	event.add('tfc:compost_browns_high', 'jellies:jellie/slime_ball/phosphorum')

--- a/pakku-lock.json
+++ b/pakku-lock.json
@@ -9915,7 +9915,7 @@
             "files": [
                 {
                     "type": "modrinth",
-                    "file_name": "Jellies-1.20.1-0.1.4.jar",
+                    "file_name": "Jellies-1.20.1-0.1.6.jar",
                     "mc_versions": [
                         "1.20.1"
                     ],
@@ -9923,20 +9923,20 @@
                         "forge"
                     ],
                     "release_type": "release",
-                    "url": "https://cdn.modrinth.com/data/9uLmCnkY/versions/BFJ6nOS0/Jellies-1.20.1-0.1.4.jar",
-                    "id": "BFJ6nOS0",
+                    "url": "https://cdn.modrinth.com/data/9uLmCnkY/versions/VeEpZE6E/Jellies-1.20.1-0.1.6.jar",
+                    "id": "VeEpZE6E",
                     "parent_id": "9uLmCnkY",
                     "hashes": {
-                        "sha512": "15976de6bd90937e2c6d8ed3fae8f89597042452e75e56aa4ff9d24e1207060da01d9f3377a8160d30c1f62d1792411194758c3d8286cd20b3c6bf928d05abe8",
-                        "sha1": "cdb85274c6c6ad3928516c76e42458becc9325af"
+                        "sha512": "e715c0daa55c4a8a295cc87aa1ddb7272066a2836a288ec6125d674571d09860dff895164f94a363ee6b6a30cf7ed7f63a94183b6623e0153c88bd0242bbfa3c",
+                        "sha1": "c7b726f18b65c1b11eb45245e6fcf83d83ee3c20"
                     },
                     "required_dependencies": [],
-                    "size": 978794,
-                    "date_published": "2026-08-06T23:48:37.187291Z"
+                    "size": 986366,
+                    "date_published": "2026-08-19T00:02:26.548291Z"
                 },
                 {
                     "type": "curseforge",
-                    "file_name": "Jellies-1.20.1-0.1.4.jar",
+                    "file_name": "Jellies-1.20.1-0.1.6.jar",
                     "mc_versions": [
                         "1.20.1"
                     ],
@@ -9944,16 +9944,16 @@
                         "forge"
                     ],
                     "release_type": "release",
-                    "url": "https://edge.forgecdn.net/files/8591/504/Jellies-1.20.1-0.1.4.jar",
-                    "id": "8591504",
+                    "url": "https://edge.forgecdn.net/files/8681/154/Jellies-1.20.1-0.1.6.jar",
+                    "id": "8681154",
                     "parent_id": "1607526",
                     "hashes": {
-                        "sha1": "cdb85274c6c6ad3928516c76e42458becc9325af",
-                        "md5": "588c08ebcd9b3ff9071f0a55333ade76"
+                        "sha1": "c7b726f18b65c1b11eb45245e6fcf83d83ee3c20",
+                        "md5": "bb3b378d82850b1d0ea5c9c2fe7cc334"
                     },
                     "required_dependencies": [],
-                    "size": 978794,
-                    "date_published": "2026-08-06T23:48:35.940Z"
+                    "size": 986366,
+                    "date_published": "2026-08-19T00:02:25.017Z"
                 }
             ]
         },


### PR DESCRIPTION
## What is the new behavior?
Changes mars and moon jellies to spawn in the axolotl category and adds main jellie food - nutritional mash.

## Implementation Details
- Updated Jellies to 0.1.6 through pakku.
- Changed mars and moon jellie spawn category.
- Added recipe for nutritional mash and added tags to its ingredients.

## Additional Information
- I will do patchouli entries separately later.