### PR TITLE
Rebalance overworld fauna spawning

### DIFF
--- a/kubejs/data/tfc/tfc/fauna/chicken.json
+++ b/kubejs/data/tfc/tfc/fauna/chicken.json
@@ -1,4 +1,5 @@
 {
+  "__comment__": "TFC original: min temperature 14, min rainfall 225, min forest edge. This only lowers min temperature from 14 to 12.",
   "climate": {
     "min_temperature": 12,
     "min_rainfall": 225,

--- a/kubejs/data/tfc/tfc/fauna/chicken.json
+++ b/kubejs/data/tfc/tfc/fauna/chicken.json
@@ -1,0 +1,7 @@
+{
+  "climate": {
+    "min_temperature": 12,
+    "min_rainfall": 225,
+    "min_forest": "edge"
+  }
+}

--- a/kubejs/data/tfc/tfc/fauna/cougar.json
+++ b/kubejs/data/tfc/tfc/fauna/cougar.json
@@ -1,0 +1,8 @@
+{
+  "chance": 4,
+  "climate": {
+    "min_temperature": -10,
+    "max_temperature": 21,
+    "min_rainfall": 150
+  }
+}

--- a/kubejs/data/tfc/tfc/fauna/cougar.json
+++ b/kubejs/data/tfc/tfc/fauna/cougar.json
@@ -1,4 +1,5 @@
 {
+  "__comment__": "TFC original chance defaults to 1, so every otherwise-eligible check passes this test. Chance 4 allows 1 in 4; climate values are unchanged.",
   "chance": 4,
   "climate": {
     "min_temperature": -10,

--- a/kubejs/data/tfc/tfc/fauna/grizzly_bear.json
+++ b/kubejs/data/tfc/tfc/fauna/grizzly_bear.json
@@ -1,4 +1,5 @@
 {
+  "__comment__": "TFC original chance defaults to 1, so every otherwise-eligible check passes this test. Chance 3 allows 1 in 3; climate values are unchanged.",
   "chance": 3,
   "climate": {
     "min_temperature": -15,

--- a/kubejs/data/tfc/tfc/fauna/grizzly_bear.json
+++ b/kubejs/data/tfc/tfc/fauna/grizzly_bear.json
@@ -1,0 +1,9 @@
+{
+  "chance": 3,
+  "climate": {
+    "min_temperature": -15,
+    "max_temperature": 15,
+    "min_rainfall": 200,
+    "min_forest": "edge"
+  }
+}

--- a/kubejs/data/tfc/tfc/fauna/panther.json
+++ b/kubejs/data/tfc/tfc/fauna/panther.json
@@ -1,0 +1,9 @@
+{
+  "chance": 4,
+  "climate": {
+    "min_temperature": 12,
+    "max_temperature": 30,
+    "min_rainfall": 250,
+    "min_forest": "edge"
+  }
+}

--- a/kubejs/data/tfc/tfc/fauna/panther.json
+++ b/kubejs/data/tfc/tfc/fauna/panther.json
@@ -1,4 +1,5 @@
 {
+  "__comment__": "TFC original: chance 1, temperature -10..21, min rainfall 150, no forest minimum. Chance 4 allows 1 in 4; this also moves panthers to warm, wet forest edge.",
   "chance": 4,
   "climate": {
     "min_temperature": 12,

--- a/kubejs/data/tfc/tfc/fauna/sabertooth.json
+++ b/kubejs/data/tfc/tfc/fauna/sabertooth.json
@@ -1,0 +1,7 @@
+{
+  "chance": 4,
+  "climate": {
+    "max_temperature": 0,
+    "min_rainfall": 250
+  }
+}

--- a/kubejs/data/tfc/tfc/fauna/sabertooth.json
+++ b/kubejs/data/tfc/tfc/fauna/sabertooth.json
@@ -1,4 +1,5 @@
 {
+  "__comment__": "TFC original chance defaults to 1, so every otherwise-eligible check passes this test. Chance 4 allows 1 in 4; climate values are unchanged.",
   "chance": 4,
   "climate": {
     "max_temperature": 0,

--- a/kubejs/data/tfc/tfc/fauna/sheep.json
+++ b/kubejs/data/tfc/tfc/fauna/sheep.json
@@ -1,4 +1,5 @@
 {
+  "__comment__": "TFC original: temperature 0..35, rainfall 70..300, no forest limit. This lowers min temperature to -10, raises max rainfall to 350, and limits sheep to sparse-or-more-open forest.",
   "climate": {
     "min_temperature": -10,
     "max_temperature": 35,

--- a/kubejs/data/tfc/tfc/fauna/sheep.json
+++ b/kubejs/data/tfc/tfc/fauna/sheep.json
@@ -1,0 +1,9 @@
+{
+  "climate": {
+    "min_temperature": -10,
+    "max_temperature": 35,
+    "min_rainfall": 70,
+    "max_rainfall": 350,
+    "max_forest": "sparse"
+  }
+}

--- a/kubejs/data/tfc/tfc/fauna/wolf.json
+++ b/kubejs/data/tfc/tfc/fauna/wolf.json
@@ -1,5 +1,6 @@
 {
   "__comment__": "This file was automatically created by mcresources",
+  "chance": 3,
   "climate": {
     "min_temperature": -20,
     "max_temperature": 22,

--- a/kubejs/data/tfc/tfc/fauna/wolf.json
+++ b/kubejs/data/tfc/tfc/fauna/wolf.json
@@ -1,5 +1,5 @@
 {
-  "__comment__": "This file was automatically created by mcresources",
+  "__comment__": "TFC chance defaults to 1, so every otherwise-eligible check passes this test. Chance 3 allows 1 in 3; the existing TFG climate override is unchanged.",
   "chance": 3,
   "climate": {
     "min_temperature": -20,


### PR DESCRIPTION
## Summary

- reduce successful spawn checks for cougars, panthers, sabertooths, wolves, and grizzly bears
- separate panthers into a warmer, wetter forest-edge niche while retaining the broader cougar climate
- broaden sheep into colder open country and slightly lower the minimum chicken temperature
- use TFC's existing fauna datapack format without adding a mod or changing the shared creature cap

## Why

Persistent, seasonally spawning wildlife can leave a region with a predator-heavy mix for a long time. These pack-native overrides make the predator/prey distribution less likely to skew toward large predators while keeping husbandry and seasonal spawning intact.

Closes #4799

## Validation

- parsed all seven fauna files with Python's JSON parser
- ran `git diff --check`
